### PR TITLE
Feature/importing activities

### DIFF
--- a/backend/app/views/backend/activities/_form.html.slim
+++ b/backend/app/views/backend/activities/_form.html.slim
@@ -7,6 +7,10 @@
   = form.file_field :picture, label: false
 
 .field
+  = form.label :short_description
+  = form.input :short_description, label: false
+
+.field
   = form.label :description
   = form.input :description, label: false
 

--- a/backend/app/views/backend/activities/_form.html.slim
+++ b/backend/app/views/backend/activities/_form.html.slim
@@ -11,6 +11,10 @@
   = form.input :description, label: false
 
 .field
+  = form.label :project_number
+  = form.input :project_number, label: false
+
+.field
   = form.association :news_articles, collection: news_articles, label_method: :title,
     value_method: :id
 .field

--- a/backend/app/views/backend/publications/_form.html.slim
+++ b/backend/app/views/backend/publications/_form.html.slim
@@ -11,6 +11,10 @@
   = form.input :description, label: false
 
 .field
+  = form.label :description
+  = form.input :description, label: false
+
+.field
   = form.label :story_map_url
   = form.input :story_map_url, label: false
 

--- a/backend/app/views/backend/publications/_form.html.slim
+++ b/backend/app/views/backend/publications/_form.html.slim
@@ -7,8 +7,8 @@
   = form.file_field :picture, label: false
 
 .field
-  = form.label :description
-  = form.input :description, label: false
+  = form.label :short_description
+  = form.input :short_description, label: false
 
 .field
   = form.label :description

--- a/db/migrate/20161012115522_add_project_number_to_contents.rb
+++ b/db/migrate/20161012115522_add_project_number_to_contents.rb
@@ -1,0 +1,5 @@
+class AddProjectNumberToContents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :contents, :project_number, :integer
+  end
+end

--- a/db/migrate/20161012122035_add_short_description_to_contents.rb
+++ b/db/migrate/20161012122035_add_short_description_to_contents.rb
@@ -1,0 +1,5 @@
+class AddShortDescriptionToContents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :contents, :short_description, :text
+  end
+end

--- a/db/migrate/20161012124142_add_foreign_keys.rb
+++ b/db/migrate/20161012124142_add_foreign_keys.rb
@@ -1,0 +1,12 @@
+class AddForeignKeys < ActiveRecord::Migration[5.0]
+  def change
+    add_foreign_key :activity_news, :contents, column: :activity_id
+    add_foreign_key :activity_news, :news_articles
+
+    add_foreign_key :participants, :users
+    add_foreign_key :participants, :contents
+
+    add_foreign_key :content_partners, :partners
+    add_foreign_key :content_partners, :contents
+  end
+end

--- a/db/migrate/20161012130848_add_is_lead_to_participants.rb
+++ b/db/migrate/20161012130848_add_is_lead_to_participants.rb
@@ -1,0 +1,5 @@
+class AddIsLeadToParticipants < ActiveRecord::Migration[5.0]
+  def change
+    add_column :participants, :is_lead, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161012115522) do
+ActiveRecord::Schema.define(version: 20161012122035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 20161012115522) do
     t.datetime "picture_updated_at"
     t.boolean  "is_featured"
     t.integer  "project_number"
+    t.text     "short_description"
   end
 
   create_table "events", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161012124142) do
+ActiveRecord::Schema.define(version: 20161012130848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,8 +83,9 @@ ActiveRecord::Schema.define(version: 20161012124142) do
   create_table "participants", force: :cascade do |t|
     t.integer  "content_id"
     t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "is_lead",    default: false
   end
 
   create_table "partners", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161012122035) do
+ActiveRecord::Schema.define(version: 20161012124142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,4 +139,10 @@ ActiveRecord::Schema.define(version: 20161012122035) do
     t.datetime "updated_at",                   null: false
   end
 
+  add_foreign_key "activity_news", "contents", column: "activity_id"
+  add_foreign_key "activity_news", "news_articles"
+  add_foreign_key "content_partners", "contents"
+  add_foreign_key "content_partners", "partners"
+  add_foreign_key "participants", "contents"
+  add_foreign_key "participants", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160927071144) do
+ActiveRecord::Schema.define(version: 20161012115522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,8 @@ ActiveRecord::Schema.define(version: 20160927071144) do
     t.string   "picture_content_type"
     t.integer  "picture_file_size"
     t.datetime "picture_updated_at"
+    t.boolean  "is_featured"
+    t.integer  "project_number"
   end
 
   create_table "events", force: :cascade do |t|
@@ -116,7 +118,7 @@ ActiveRecord::Schema.define(version: 20160927071144) do
     t.string   "web_url"
     t.boolean  "active",                 default: false, null: false
     t.datetime "deactivated_at"
-    t.integer  "role",                   default: 0,     null: false
+    t.integer  "role",                   default: 0,     null: false, comment: "User role { contributor: 0, publisher: 1, admin: 2 }"
     t.datetime "locked_at"
     t.integer  "failed_attempts",        default: 0,     null: false
     t.string   "unlock_token"
@@ -126,6 +128,14 @@ ActiveRecord::Schema.define(version: 20160927071144) do
     t.datetime "avatar_updated_at"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  end
+
+  create_table "vacancies", force: :cascade do |t|
+    t.string   "title"
+    t.string   "description"
+    t.boolean  "is_published", default: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
   end
 
 end


### PR DESCRIPTION
Imports activities from doc provided by Grid Arendal. It's not yet finished but a first version that will allow you to see some data for Activities.

This PR requires: `rails db:migrate`
To import the activities run: `rails import:activities`