### PR TITLE
fix turbolinks preventing page reload event

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require jquery
+//= require turbolinks
 
 //= require jquery
 //= require URIjs

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // about supported directives.
 //
 //= require jquery
-//= require turbolinks
 
 //= require jquery
 //= require URIjs

--- a/app/assets/javascripts/dispatcher.js
+++ b/app/assets/javascripts/dispatcher.js
@@ -56,7 +56,7 @@
    * App will be start when DOM is ready
    */
   function initApp() {
-    new Dispatcher();
+    this.dispatcher = new Dispatcher();
 
     if (Backbone.History.started) {
       Backbone.history.stop();
@@ -64,9 +64,17 @@
 
     // Start listening changes in routes
     Backbone.history.start({ pushState: true });
-  }
+  };
+
+  function reloadApp() {
+    Backbone.history.stop();
+    this.initApp();
+  };
 
   document.addEventListener('DOMContentLoaded', initApp);
+
+  document.addEventListener('page:load', reloadApp);
+
 
 
 })(this.App);

--- a/app/assets/javascripts/dispatcher.js
+++ b/app/assets/javascripts/dispatcher.js
@@ -56,7 +56,7 @@
    * App will be start when DOM is ready
    */
   function initApp() {
-    this.dispatcher = new Dispatcher();
+    new Dispatcher();
 
     if (Backbone.History.started) {
       Backbone.history.stop();
@@ -66,15 +66,12 @@
     Backbone.history.start({ pushState: true });
   };
 
-  function reloadApp() {
-    Backbone.history.stop();
-    this.initApp();
-  };
 
-  document.addEventListener('DOMContentLoaded', initApp);
-
-  document.addEventListener('page:load', reloadApp);
-
-
+  /*
+   * As we will using turbolinks, we will listen to the turbolinks
+   * load event and we will refresh the app each time the page loads.
+   */
+  // document.addEventListener('DOMContentLoaded', initApp);
+  document.addEventListener('turbolinks:load', initApp);
 
 })(this.App);

--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -11,16 +11,10 @@
      */
     routes: {
       '': 'Home#index',
-
       'publications': 'Publications#index',
       'publications/:id': 'Publications#show',
-
       'activities': 'Activities#index',
-      'activities/:id': 'Activities#show',
-
-      // Here you have an example
-      // 'countries': 'Countries#index',
-      // 'countries/:iso': 'Countries#show'
+      'activities/:id': 'Activities#show'
     },
 
     initialize: function() {

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,6 +6,7 @@ html
     meta name='viewport' content='width=device-width, initial-scale=1.0'
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    / In order to be able to use the turbolink event, we need to add the script here instead of in the body to avoid continous reloads.
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   body
     = render 'shared/icons'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,4 +9,4 @@ html
     = render 'shared/icons'
   body
     = yield
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application', 'data-turbolinks-track': false

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,7 +6,8 @@ html
     meta name='viewport' content='width=device-width, initial-scale=1.0'
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = render 'shared/icons'
+    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   body
+    = render 'shared/icons'
     = yield
-    = javascript_include_tag 'application', 'data-turbolinks-track': false
+


### PR DESCRIPTION
Here you have the fix for the JS not working when navigating. 
We had something called turbolinks that was avoiding the event we are waiting for actualize the router. 
Now JS should work all along the page. 