### PR TITLE
Adds content_date for the two types of content

### DIFF
--- a/backend/app/views/backend/activities/_form.html.slim
+++ b/backend/app/views/backend/activities/_form.html.slim
@@ -8,6 +8,8 @@ div.fields
 
   = render 'backend/shared/form/field_textarea', form: form, value: :description
 
+  = render 'backend/shared/form/field_input', form: form, value: :content_date, js_trigger_class: 'js-select'
+
   = render 'backend/shared/form/field_input', form: form, value: :story_map_url
 
   = render 'backend/shared/form/field_input', form: form, value: :project_number

--- a/backend/app/views/backend/publications/_form.html.slim
+++ b/backend/app/views/backend/publications/_form.html.slim
@@ -9,6 +9,8 @@ div.fields
 
   = render 'backend/shared/form/field_input', form: form, value: :story_map_url
 
+  = render 'backend/shared/form/field_input', form: form, value: :content_date, js_trigger_class: 'js-select'
+
 div.fields.-grey
 
   = render 'backend/shared/form/field_association', form: form, value: :users, collection: users, label_method: :display_name, js_trigger_class: 'js-select-tags'

--- a/db/migrate/20161122102250_add_content_date_to_contents.rb
+++ b/db/migrate/20161122102250_add_content_date_to_contents.rb
@@ -1,0 +1,5 @@
+class AddContentDateToContents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :contents, :content_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161121120619) do
+ActiveRecord::Schema.define(version: 20161122102250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 20161121120619) do
     t.boolean  "is_featured"
     t.integer  "project_number"
     t.text     "short_description"
+    t.date     "content_date"
   end
 
   create_table "events", force: :cascade do |t|


### PR DESCRIPTION
Talking with Rob from Grid Arendal he pointed out that we were missing a content date for Publications and Activities. This PR adds this. And includes it in the forms, though it doesn't display it anywhere in the front. Something to do later.

Requires:

`rails db:migrate`