### PR TITLE
Feature/types for content

### DIFF
--- a/backend/app/assets/javascripts/backend/router.js
+++ b/backend/app/assets/javascripts/backend/router.js
@@ -29,6 +29,9 @@
       'manage/events': 'BackOfficeHome#index',
       'manage/events/:id(/:action)': 'BackOfficeHome#show',
       'manage/events/new': 'BackOfficeHome#show',
+      'manage/content_types': 'BackOfficeHome#index',
+      'manage/content_types/:id(/:action)': 'BackOfficeHome#show',
+      'manage/content_types/new': 'BackOfficeHome#show',
     },
 
     initialize: function() {

--- a/backend/app/controllers/backend/activities_controller.rb
+++ b/backend/app/controllers/backend/activities_controller.rb
@@ -5,7 +5,7 @@ module Backend
   class ActivitiesController < ::Backend::ApplicationController
     load_and_authorize_resource
 
-    before_action :set_users_partners_and_news, only: [:new, :edit]
+    before_action :set_objects, only: [:new, :edit]
 
     def index
       @activities = Activity.order(:title)
@@ -25,7 +25,7 @@ module Backend
       if @activity.update(activity_params)
         redirect_to activities_url, notice: 'Activity updated'
       else
-        set_users_partners_and_news
+        set_objects
         @activities = Activity.order(:title)
         render :edit
       end
@@ -36,7 +36,7 @@ module Backend
       if @activity.save
         redirect_to activities_url
       else
-        set_users_partners_and_news
+        set_objects
         @activities = Activity.order(:title)
         render :new
       end
@@ -75,11 +75,14 @@ module Backend
         params.require(:activity).permit!
       end
 
-      def set_users_partners_and_news
+      def set_objects
         @users = User.order(:first_name, :last_name)
         @partners = Partner.order(:name)
         @news_articles = NewsArticle.order(:title)
         @publications = Publication.order(:title)
+        @content_types = ContentType.
+          where(for_content: [ContentType::BOTH, ContentType::ACTIVITY]).
+          order(:title)
       end
   end
 end

--- a/backend/app/controllers/backend/content_types_controller.rb
+++ b/backend/app/controllers/backend/content_types_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require_dependency 'backend/application_controller'
+
+module Backend
+  class ContentTypesController < ::Backend::ApplicationController
+    load_and_authorize_resource
+
+    before_action :set_content_type, only: [:edit, :create, :update]
+    before_action :set_content_types
+
+    def index
+    end
+
+    def edit
+    end
+
+    def new
+      @content_type = ContentType.new
+    end
+
+    def update
+      if @content_type.update(content_type_params)
+        redirect_to content_types_url, notice: 'ContentType updated'
+      else
+        render :edit
+      end
+    end
+
+    def create
+      @content_type = ContentType.create(content_type_params)
+      if @content_type.save
+        redirect_to content_types_url
+      else
+        render :new
+      end
+    end
+
+    def destroy
+      if @content_type.destroy
+        redirect_to content_types_url
+      end
+    end
+
+    private
+
+      def set_content_type
+        @content_type = ContentType.find(params[:id])
+      end
+
+      def set_content_types
+        @content_types = ContentType.order(:title)
+      end
+
+      def content_type_params
+        params.require(:content_type).permit!
+      end
+  end
+end

--- a/backend/app/controllers/backend/content_types_controller.rb
+++ b/backend/app/controllers/backend/content_types_controller.rb
@@ -5,7 +5,7 @@ module Backend
   class ContentTypesController < ::Backend::ApplicationController
     load_and_authorize_resource
 
-    before_action :set_content_type, only: [:edit, :create, :update]
+    before_action :set_content_type, only: [:edit, :update, :destroy]
     before_action :set_content_types
 
     def index

--- a/backend/app/controllers/backend/publications_controller.rb
+++ b/backend/app/controllers/backend/publications_controller.rb
@@ -5,7 +5,7 @@ module Backend
   class PublicationsController < ::Backend::ApplicationController
     load_and_authorize_resource
 
-    before_action :set_users_and_partners, only: [:new, :edit]
+    before_action :set_objects, only: [:new, :edit]
     before_action :publications,
 
 
@@ -24,7 +24,7 @@ module Backend
       if @publication.update(publication_params)
         redirect_to publications_url, notice: 'Publication updated'
       else
-        set_users_and_partners
+        set_objects
         render :edit
       end
     end
@@ -34,7 +34,7 @@ module Backend
       if @publication.save
         redirect_to publications_url
       else
-        set_users_and_partners
+        set_objects
         render :new
       end
     end
@@ -76,9 +76,12 @@ module Backend
         @publications = Publication.order(:title)
       end
 
-      def set_users_and_partners
+      def set_objects
         @users    = User.order_by_fullname
         @partners = Partner.order_by_name
+        @content_types = ContentType.
+          where(for_content: [ContentType::BOTH, ContentType::PUBLICATION]).
+          order(:title)
       end
   end
 end

--- a/backend/app/models/content.rb
+++ b/backend/app/models/content.rb
@@ -29,6 +29,7 @@ class Content < ApplicationRecord
 
   has_many :content_partners
   has_many :partners, through: :content_partners
+  belongs_to :content_type
 
   validates :title, presence: true
 end

--- a/backend/app/models/content_type.rb
+++ b/backend/app/models/content_type.rb
@@ -1,0 +1,13 @@
+# == Schema Information
+#
+# Table name: content_types
+#
+#  id          :integer          not null, primary key
+#  for_content :string           not null
+#  title       :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+class ContentType < ApplicationRecord
+end

--- a/backend/app/models/content_type.rb
+++ b/backend/app/models/content_type.rb
@@ -12,7 +12,10 @@
 class ContentType < ApplicationRecord
   has_many :contents
 
-  FOR_CONTENT = ["Activity and Publications", "Activity", "Publication"]
+  BOTH = "Activity and Publication"
+  ACTIVITY = "Activity"
+  PUBLICATION = "Publication"
+  FOR_CONTENT = [BOTH, ACTIVITY, PUBLICATION]
 
   validates :title, presence: true
   validates :for_content, presence: true

--- a/backend/app/models/content_type.rb
+++ b/backend/app/models/content_type.rb
@@ -12,5 +12,10 @@
 class ContentType < ApplicationRecord
   has_many :contents
 
-  FOR_CONTENT = ["both", "Activity", "Publication"]
+  FOR_CONTENT = ["Activity and Publications", "Activity", "Publication"]
+
+  validates :title, presence: true
+  validates :for_content, presence: true
+  validates :for_content,
+    inclusion: { in: FOR_CONTENT, message: "%{value} is not a valid value" }
 end

--- a/backend/app/models/content_type.rb
+++ b/backend/app/models/content_type.rb
@@ -10,4 +10,7 @@
 #
 
 class ContentType < ApplicationRecord
+  has_many :contents
+
+  FOR_CONTENT = ["both", "Activity", "Publication"]
 end

--- a/backend/app/views/backend/activities/_form.html.slim
+++ b/backend/app/views/backend/activities/_form.html.slim
@@ -1,6 +1,9 @@
 = render 'backend/shared/form/header', form: form, value: :title, title_placeholder: 'Activity title'
 
 div.fields
+  = render 'backend/shared/form/field_association', form: form, value: :content_type,
+    collection: content_types, label_method: :title, js_trigger_class: 'js-select-tags',
+    note_txt: 'Choose type'
 
   = render 'backend/shared/form/field_upload_img', form: form, value: :picture, label_txt: 'Picture', have_picture: have_picture, picture_url: picture_url
 

--- a/backend/app/views/backend/activities/edit.html.erb
+++ b/backend/app/views/backend/activities/edit.html.erb
@@ -14,6 +14,7 @@
       partners: @partners,
       news_articles: @news_articles,
       publications: @publications,
+      content_types: @content_types,
       have_picture: @activity.picture_file_name ? true : false,
       picture_url: @activity.picture %>
   <% end %>

--- a/backend/app/views/backend/activities/new.html.erb
+++ b/backend/app/views/backend/activities/new.html.erb
@@ -14,6 +14,7 @@
       partners: @partners,
       news_articles: @news_articles,
       publications: @publications,
+      content_types: @content_types,
       have_picture: false,
       picture_url: nil %>
   <% end %>

--- a/backend/app/views/backend/content_types/_content_types.html.erb
+++ b/backend/app/views/backend/content_types/_content_types.html.erb
@@ -1,0 +1,27 @@
+<h2 class="text -main-title -light">Content types</h2>
+
+<div class="buttons-bar">
+  <% if can?(:create, ContentType) %>
+    <%= link_to "Create New", new_content_type_path, class: 'btn -light -no-border -create-new js-create-new' %>
+  <% end %>
+  <div class="btn">
+    <svg class="icon">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search"></use>
+    </svg>
+  </div>
+  <div class="btn">
+    <svg class="icon">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-sort"></use>
+    </svg>
+  </div>
+</div>
+
+<ul class="items-list">
+  <% @content_types.each do |content_type| %>
+    <%= render 'backend/shared/index_item',
+      item: content_type,
+      title: content_type.title,
+      edit_path: edit_content_type_path(content_type),
+      delete_path: content_type_path(content_type) %>
+  <% end %>
+</ul>

--- a/backend/app/views/backend/content_types/_form.html.slim
+++ b/backend/app/views/backend/content_types/_form.html.slim
@@ -1,1 +1,7 @@
 = render 'backend/shared/form/header', form: form, value: :title, title_placeholder: 'Content type title'
+
+.fields
+  = render 'backend/shared/form/field_select', form: form, value: :for_content,
+    collection: ContentType::FOR_CONTENT, include_blank: false,
+    label_txt: "For content", input_as: :select
+  = render 'backend/shared/form/field_textarea', form: form, value: :description

--- a/backend/app/views/backend/content_types/_form.html.slim
+++ b/backend/app/views/backend/content_types/_form.html.slim
@@ -1,0 +1,1 @@
+= render 'backend/shared/form/header', form: form, value: :title, title_placeholder: 'Content type title'

--- a/backend/app/views/backend/content_types/edit.html.erb
+++ b/backend/app/views/backend/content_types/edit.html.erb
@@ -1,0 +1,13 @@
+<div class="l-navigation">
+  <%= render 'backend/shared/nav_bar' %>
+</div>
+
+<div class="l-items-index">
+  <%= render 'content_types', content_types: @content_types %>
+</div>
+
+<div class="l-items-detail">
+  <%= simple_form_for @content_type, html: { class: 'c-form' } do |f| %>
+    <%= render 'form', form: f %>
+  <% end %>
+</div>

--- a/backend/app/views/backend/content_types/index.html.erb
+++ b/backend/app/views/backend/content_types/index.html.erb
@@ -1,0 +1,11 @@
+<div class="l-navigation">
+  <%= render 'backend/shared/nav_bar' %>
+</div>
+
+<div class="l-items-index">
+  <%= render 'content_types', content_types: @content_types %>
+</div>
+
+<div class="l-items-detail">
+  <%= render 'backend/shared/phrases' %>
+</div>

--- a/backend/app/views/backend/content_types/new.html.erb
+++ b/backend/app/views/backend/content_types/new.html.erb
@@ -1,0 +1,13 @@
+<div class="l-navigation">
+  <%= render 'backend/shared/nav_bar' %>
+</div>
+
+<div class="l-items-index">
+  <%= render 'content_types', content_types: @content_types %>
+</div>
+
+<div class="l-items-detail">
+  <%= simple_form_for @content_type, html: { class: 'c-form' } do |f| %>
+    <%= render 'form', form: f %>
+  <% end %>
+</div>

--- a/backend/app/views/backend/events/_form.html.slim
+++ b/backend/app/views/backend/events/_form.html.slim
@@ -8,6 +8,7 @@ div.fields
 
   = render 'backend/shared/form/field_textarea', form: form, value: :description
 
-  = render 'backend/shared/form/field_select', form: form, value: :partner_id, collection: partners, label_txt: 'Partner'
+  = render 'backend/shared/form/field_select', form: form, value: :partner_id,
+    collection: partners, label_txt: 'Partner', input_as: :collection_select
 
   = render 'backend/shared/form/field_checkbox', form: form, value: :active

--- a/backend/app/views/backend/publications/_form.html.slim
+++ b/backend/app/views/backend/publications/_form.html.slim
@@ -1,6 +1,10 @@
 = render 'backend/shared/form/header', form: form, value: :title, title_placeholder: 'Publication title'
 
 div.fields
+  = render 'backend/shared/form/field_association', form: form, value: :content_type,
+    collection: content_types, label_method: :title, js_trigger_class: 'js-select-tags',
+    note_txt: 'Choose type'
+
   = render 'backend/shared/form/field_upload_img', form: form, value: :picture, label_txt: 'Cover picture', have_picture: have_picture, picture_url: picture_url
 
   = render 'backend/shared/form/field_limited_input', form: form, value: :short_description, maxlength: 140

--- a/backend/app/views/backend/publications/edit.html.erb
+++ b/backend/app/views/backend/publications/edit.html.erb
@@ -12,6 +12,7 @@
       form: f,
       users: @users,
       partners: @partners,
+      content_types: @content_types,
       have_picture: @publication.picture_file_name ? true : false,
       picture_url: @publication.picture %>
   <% end %>

--- a/backend/app/views/backend/publications/new.html.erb
+++ b/backend/app/views/backend/publications/new.html.erb
@@ -12,6 +12,7 @@
       form: f,
       users: @users,
       partners: @partners,
+      content_types: @content_types,
       have_picture: false,
       picture_url: nil %>
   <% end %>

--- a/backend/app/views/backend/shared/_nav_bar.html.slim
+++ b/backend/app/views/backend/shared/_nav_bar.html.slim
@@ -8,7 +8,8 @@ ul.basic-nav
             {"name" => "Events", "path" => events_path, "key" => "events"},
             {"name" => "Media contents", "path" => new_media_content_path("mediable" => 'photo'), "key" => "media_contents"},
             {"name" => "Partners", "path" => partners_path, "key" => "partners"},
-            {"name" => "Users", "path" => users_path, "key" => "users"}]
+            {"name" => "Users", "path" => users_path, "key" => "users"},
+            {"name" => "Content types", "path" => content_types_path, "key" => "content_types"}]
 
     li.-user.-no-hover
       img.avatar src="https://pbs.twimg.com/profile_images/794258346115268614/odGvBrDx_bigger.jpg"

--- a/backend/app/views/backend/shared/form/_field_select.html.slim
+++ b/backend/app/views/backend/shared/form/_field_select.html.slim
@@ -1,8 +1,10 @@
+- include_blank ||= false
+
 .field
   = form.label value, label_txt, class: 'text -field-label -bold -dark'
   = form.input value,
     collection: collection,
-    as: :collection_select,
-    include_blank: false,
+    as: input_as,
+    include_blank: include_blank,
     label: false,
     input_html: {class: 'basic-input text -plain-text -dark js-select'}

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -47,6 +47,8 @@ Backend::Engine.routes.draw do
     patch 'activate',   on: :member
   end
 
+  resources :content_types, except: :show
+
   resources :media_contents, except: :show do
     patch 'publish',   on: :member
     patch 'unpublish', on: :member

--- a/db/migrate/20161123180837_create_content_types.rb
+++ b/db/migrate/20161123180837_create_content_types.rb
@@ -1,0 +1,10 @@
+class CreateContentTypes < ActiveRecord::Migration[5.0]
+  def change
+    create_table :content_types do |t|
+      t.string :for_content, null: false
+      t.string :title, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20161123182620_add_content_type_id_to_contents.rb
+++ b/db/migrate/20161123182620_add_content_type_id_to_contents.rb
@@ -1,0 +1,5 @@
+class AddContentTypeIdToContents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :contents, :content_type_id, :integer
+  end
+end

--- a/db/migrate/20161124111648_add_description_to_content_types.rb
+++ b/db/migrate/20161124111648_add_description_to_content_types.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToContentTypes < ActiveRecord::Migration[5.0]
+  def change
+    add_column :content_types, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161123180837) do
+ActiveRecord::Schema.define(version: 20161123182620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 20161123180837) do
     t.integer  "project_number"
     t.text     "short_description"
     t.date     "content_date"
+    t.integer  "content_type_id"
   end
 
   create_table "events", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161122102250) do
+ActiveRecord::Schema.define(version: 20161123180837) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,13 @@ ActiveRecord::Schema.define(version: 20161122102250) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "content_types", force: :cascade do |t|
+    t.string   "for_content", null: false
+    t.string   "title",       null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
   create_table "contents", force: :cascade do |t|
     t.string   "type"
     t.string   "title"
@@ -72,9 +79,9 @@ ActiveRecord::Schema.define(version: 20161122102250) do
     t.string   "picture_content_type"
     t.integer  "picture_file_size"
     t.datetime "picture_updated_at"
+    t.boolean  "is_featured"
     t.integer  "project_number"
     t.text     "short_description"
-    t.boolean  "is_featured"
     t.date     "content_date"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161123182620) do
+ActiveRecord::Schema.define(version: 20161124111648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20161123182620) do
     t.string   "title",       null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.text     "description"
   end
 
   create_table "contents", force: :cascade do |t|

--- a/features/content_types.feature
+++ b/features/content_types.feature
@@ -1,0 +1,34 @@
+Feature: Content Types
+In order to manage content types
+As an adminuser
+I want to edit, create, view content types
+
+  Scenario: User can view content types page and content type page
+    Given I am authenticated adminuser
+    And content type
+    When I go to the content types page
+    And I should see "Content Type one"
+
+  Scenario: Adminuser can edit content type
+    Given content type
+    And I am authenticated adminuser
+    When I go to the edit content type page for "Content Type one"
+    And I fill in "Title" with "Content Type edited"
+    And I press "SAVE"
+    Then I should see "Content Type edited"
+
+  Scenario: Adminuser can create content type
+    Given I am authenticated adminuser
+    When I go to the new content type page
+    And I fill in "Title" with "Content Type new"
+    And I press "SAVE"
+    Then I should have one content type
+    And I should see "Content Type new"
+
+  Scenario: Adminuser can not create content type without name
+    Given I am authenticated adminuser
+    When I go to the new content type page
+    And I fill in "Title" with ""
+    And I press "SAVE"
+    Then I should have zero content types
+    And I should see "can't be blank"

--- a/features/step_definitions/content_type_steps.rb
+++ b/features/step_definitions/content_type_steps.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+Then /^I should have zero content types$/ do
+  expect(ContentType.all.size).to eq(0)
+end
+
+Then /^I should have one content type$/ do
+  expect(ContentType.all.size).to eq(1)
+end
+
+Then /^I should have two content types$/ do
+  expect(ContentType.all.size).to eq(2)
+end
+
+Given /^content type$/ do
+  FactoryGirl.create(:content_type)
+end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -44,6 +44,12 @@ module NavigationHelpers
       backend.new_event_path
     when /the edit event page for "(.*)"$/
       backend.edit_event_path(Event.find_by(title: $1).id)
+    when /the content types page/
+      backend.content_types_path
+    when /the new content type page/
+      backend.new_content_type_path
+    when /the edit content type page for "(.*)"$/
+      backend.edit_content_type_path(ContentType.find_by(title: $1).id)
     when /the news_articles page/
       backend.news_articles_path
     when /the new news_article page/

--- a/spec/backend/controllers/content_types_controller_spec.rb
+++ b/spec/backend/controllers/content_types_controller_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+module Backend
+  RSpec.describe ContentTypesController, type: :controller do
+    routes { Backend::Engine.routes }
+
+    before :each do
+      @content_type         = create(:content_type)
+      @adminuser     = create(:user, email: 'admin@sample.com', active: true, role: 'admin', first_name: 'Juanito')
+    end
+
+    let!(:attri) do
+      { title: 'Update content type' }
+    end
+
+    let!(:attri_fail) do
+      { title: '' }
+    end
+
+    context 'For authenticated user' do
+      before :each do
+        sign_in @adminuser
+      end
+
+      it 'GET index returns http success' do
+        process :index
+        expect(response).to be_success
+        expect(response).to have_http_status(200)
+      end
+
+      it 'GET edit returns http success' do
+        process :edit, params: { id: @content_type.id }
+        expect(response).to be_success
+        expect(response).to have_http_status(200)
+      end
+
+      it 'Update content type' do
+        process :update, method: :put, params: { id: @content_type.id, content_type: attri }
+        expect(response).to be_redirect
+        expect(response).to have_http_status(302)
+      end
+
+      render_views
+
+      it 'Validate content_type title presence' do
+        process :update, method: :put, params: { id: @content_type.id, content_type: attri_fail }
+        expect(response.body).to match('can&#39;t be blank')
+      end
+    end
+  end
+end

--- a/spec/factories/content_type.rb
+++ b/spec/factories/content_type.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :content_type do
+    title       'Content Type one'
+    for_content ContentType::BOTH
+    description Faker::Lorem.paragraph
+  end
+end


### PR DESCRIPTION
This PR adds:

* content_types model to associate a type to Activities and Publications;
* adds the controllers, routes, views, and model as necessary;
* sets up the relationship between Activity / Publication && Content Type.
* adds specs and cucumber features to manage content types

Requires that you run:

`rails db:migrate`

I'd like to ask you to check the styles of the dropdown "For Content" on the following URL if you could, @pjosh : `http://localhost:3000/manage/content_types/new` . I'm using the same partial `_input_select.html.erb` that you created, but because it's not an association it doesn't seem to be working exactly like it should. Thank you!

Styles will also be needed (sorry I'm not really good at them) for the "Content Type" selection on Activities and Publications forms.

Attached from Zeplin:
![screen shot 2016-11-24 at 12 13 51](https://cloud.githubusercontent.com/assets/10764/20598134/80a940ac-b23f-11e6-8a47-8912fbbdc659.png)
