### PR TITLE
Allows adding Tags to Activities and Publications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'paperclip-dropbox'
 gem 'flickraw'
 gem 'cocoon'
 
+# Content
+gem 'acts-as-taggable-on', '~> 4.0'
+
 group :development, :test do
   gem 'hirb'
   gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (4.0.0)
+      activerecord (>= 4.0)
     addressable (2.4.0)
     annotate (2.7.1)
       activerecord (>= 3.2, < 6.0)
@@ -344,6 +346,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 4.0)
   annotate
   autoprefixer-rails (~> 6.5.1)
   awesome_print

--- a/backend/app/assets/javascripts/backend/router.js
+++ b/backend/app/assets/javascripts/backend/router.js
@@ -32,6 +32,9 @@
       'manage/content_types': 'BackOfficeHome#index',
       'manage/content_types/:id(/:action)': 'BackOfficeHome#show',
       'manage/content_types/new': 'BackOfficeHome#show',
+      'manage/tags': 'BackOfficeHome#index',
+      'manage/tags/:id(/:action)': 'BackOfficeHome#show',
+      'manage/tags/new': 'BackOfficeHome#show',
     },
 
     initialize: function() {

--- a/backend/app/controllers/backend/tags_controller.rb
+++ b/backend/app/controllers/backend/tags_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require_dependency 'backend/application_controller'
+
+module Backend
+  class TagsController < ::Backend::ApplicationController
+    load_and_authorize_resource
+
+    before_action :set_tag, only: [:edit, :update, :destroy]
+    before_action :set_tags
+
+    def index
+    end
+
+    def edit
+    end
+
+    def new
+      @tag = Tag.new
+    end
+
+    def update
+      if @tag.update(tag_params)
+        redirect_to tags_url, notice: 'Tag updated'
+      else
+        render :edit
+      end
+    end
+
+    def create
+      @tag = Tag.create(tag_params)
+      if @tag.save
+        redirect_to tags_url
+      else
+        render :new
+      end
+    end
+
+    def destroy
+      if @tag.destroy
+        redirect_to tags_url
+      end
+    end
+
+    private
+
+      def set_tag
+        @tag = Tag.find(params[:id])
+      end
+
+      def set_tags
+        @tags = Tag.order(:name)
+      end
+
+      def tag_params
+        params.require(:tag).permit!
+      end
+  end
+end

--- a/backend/app/models/abilities/publisher_user.rb
+++ b/backend/app/models/abilities/publisher_user.rb
@@ -15,6 +15,7 @@ module Abilities
         can :manage, ::Activity
         can :manage, ::Publication
         can :manage, ::MediaContent
+        can :manage, ::Tag
         can :manage, ::Vacancy
         can [:publish, :unpublish], ::MediaContent
         can [:publish, :unpublish, :make_featured, :remove_featured], ::Activity

--- a/backend/app/models/content.rb
+++ b/backend/app/models/content.rb
@@ -24,6 +24,8 @@ class Content < ApplicationRecord
   include Featurable
   include Attachable::Picture
 
+  acts_as_taggable
+
   has_many :participants
   has_many :users, through: :participants
 

--- a/backend/app/models/tag.rb
+++ b/backend/app/models/tag.rb
@@ -1,0 +1,3 @@
+class Tag < ApplicationRecord
+  CATEGORIES = ["Activity Area", "Programme", "Region", "Theme"]
+end

--- a/backend/app/views/backend/activities/_form.html.slim
+++ b/backend/app/views/backend/activities/_form.html.slim
@@ -1,6 +1,8 @@
 = render 'backend/shared/form/header', form: form, value: :title, title_placeholder: 'Activity title'
 
 div.fields
+  = render 'backend/shared/form/field_input', form: form, value: :tag_list
+
   = render 'backend/shared/form/field_association', form: form, value: :content_type,
     collection: content_types, label_method: :title, js_trigger_class: 'js-select-tags',
     note_txt: 'Choose type'

--- a/backend/app/views/backend/publications/_form.html.slim
+++ b/backend/app/views/backend/publications/_form.html.slim
@@ -1,6 +1,8 @@
 = render 'backend/shared/form/header', form: form, value: :title, title_placeholder: 'Publication title'
 
 div.fields
+  = render 'backend/shared/form/field_input', form: form, value: :tag_list
+
   = render 'backend/shared/form/field_association', form: form, value: :content_type,
     collection: content_types, label_method: :title, js_trigger_class: 'js-select-tags',
     note_txt: 'Choose type'

--- a/backend/app/views/backend/shared/_nav_bar.html.slim
+++ b/backend/app/views/backend/shared/_nav_bar.html.slim
@@ -9,7 +9,8 @@ ul.basic-nav
             {"name" => "Media contents", "path" => new_media_content_path("mediable" => 'photo'), "key" => "media_contents"},
             {"name" => "Partners", "path" => partners_path, "key" => "partners"},
             {"name" => "Users", "path" => users_path, "key" => "users"},
-            {"name" => "Content types", "path" => content_types_path, "key" => "content_types"}]
+            {"name" => "Content types", "path" => content_types_path, "key" => "content_types"},
+            {"name" => "Tags", "path" => tags_path, "key" => "tags"}]
 
     li.-user.-no-hover
       img.avatar src="https://pbs.twimg.com/profile_images/794258346115268614/odGvBrDx_bigger.jpg"

--- a/backend/app/views/backend/tags/_form.html.slim
+++ b/backend/app/views/backend/tags/_form.html.slim
@@ -1,0 +1,6 @@
+= render 'backend/shared/form/header', form: form, value: :name, title_placeholder: 'Tag'
+
+.fields
+  = render 'backend/shared/form/field_select', form: form, value: :category,
+    collection: Tag::CATEGORIES, include_blank: true,
+    label_txt: "Tag Category", input_as: :select

--- a/backend/app/views/backend/tags/_tags.html.erb
+++ b/backend/app/views/backend/tags/_tags.html.erb
@@ -1,0 +1,27 @@
+<h2 class="text -main-title -light">Tags</h2>
+
+<div class="buttons-bar">
+  <% if can?(:create, Tag) %>
+    <%= link_to "Create New", new_tag_path, class: 'btn -light -no-border -create-new js-create-new' %>
+  <% end %>
+  <div class="btn">
+    <svg class="icon">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search"></use>
+    </svg>
+  </div>
+  <div class="btn">
+    <svg class="icon">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-sort"></use>
+    </svg>
+  </div>
+</div>
+
+<ul class="items-list">
+  <% @tags.each do |tag| %>
+    <%= render 'backend/shared/index_item',
+      item: tag,
+      title: tag.name,
+      edit_path: edit_tag_path(tag),
+      delete_path: tag_path(tag) %>
+  <% end %>
+</ul>

--- a/backend/app/views/backend/tags/edit.html.erb
+++ b/backend/app/views/backend/tags/edit.html.erb
@@ -1,0 +1,13 @@
+<div class="l-navigation">
+  <%= render 'backend/shared/nav_bar' %>
+</div>
+
+<div class="l-items-index">
+  <%= render 'tags', tags: @tags %>
+</div>
+
+<div class="l-items-detail">
+  <%= simple_form_for @tag, html: { class: 'c-form' } do |f| %>
+    <%= render 'form', form: f %>
+  <% end %>
+</div>

--- a/backend/app/views/backend/tags/index.html.erb
+++ b/backend/app/views/backend/tags/index.html.erb
@@ -1,0 +1,11 @@
+<div class="l-navigation">
+  <%= render 'backend/shared/nav_bar' %>
+</div>
+
+<div class="l-items-index">
+  <%= render 'tags', tags: @tags %>
+</div>
+
+<div class="l-items-detail">
+  <%= render 'backend/shared/phrases' %>
+</div>

--- a/backend/app/views/backend/tags/new.html.erb
+++ b/backend/app/views/backend/tags/new.html.erb
@@ -1,0 +1,13 @@
+<div class="l-navigation">
+  <%= render 'backend/shared/nav_bar' %>
+</div>
+
+<div class="l-items-index">
+  <%= render 'tags', tags: @tags %>
+</div>
+
+<div class="l-items-detail">
+  <%= simple_form_for @tag, html: { class: 'c-form' } do |f| %>
+    <%= render 'form', form: f %>
+  <% end %>
+</div>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -49,6 +49,8 @@ Backend::Engine.routes.draw do
 
   resources :content_types, except: :show
 
+  resources :tags, except: :show
+
   resources :media_contents, except: :show do
     patch 'publish',   on: :member
     patch 'unpublish', on: :member

--- a/db/migrate/20161124183104_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20161124183104_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,31 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20161124183105_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20161124183105_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,21 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20161124183106_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20161124183106_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20161124183107_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20161124183107_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20161124183108_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20161124183108_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+class ChangeCollationForTagNames < ActiveRecord::Migration
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20161124183109_add_missing_indexes.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20161124183109_add_missing_indexes.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+class AddMissingIndexes < ActiveRecord::Migration
+  def change
+    add_index :taggings, :tag_id
+    add_index :taggings, :taggable_id
+    add_index :taggings, :taggable_type
+    add_index :taggings, :tagger_id
+    add_index :taggings, :context
+
+    add_index :taggings, [:tagger_id, :tagger_type]
+    add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+  end
+end

--- a/db/migrate/20161125121452_add_category_to_tags.rb
+++ b/db/migrate/20161125121452_add_category_to_tags.rb
@@ -1,0 +1,5 @@
+class AddCategoryToTags < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tags, :category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161124111648) do
+ActiveRecord::Schema.define(version: 20161125121452) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -157,6 +157,32 @@ ActiveRecord::Schema.define(version: 20161124111648) do
     t.integer  "publication_id"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer  "tag_id"
+    t.string   "taggable_type"
+    t.integer  "taggable_id"
+    t.string   "tagger_type"
+    t.integer  "tagger_id"
+    t.string   "context",       limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context", using: :btree
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+    t.index ["tag_id"], name: "index_taggings_on_tag_id", using: :btree
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy", using: :btree
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id", using: :btree
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type", using: :btree
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type", using: :btree
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id", using: :btree
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string  "name"
+    t.integer "taggings_count", default: 0
+    t.string  "category"
+    t.index ["name"], name: "index_tags_on_name", unique: true, using: :btree
   end
 
   create_table "users", force: :cascade do |t|

--- a/features/step_definitions/tag_steps.rb
+++ b/features/step_definitions/tag_steps.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+Then /^I should have zero tags$/ do
+  expect(Tag.all.size).to eq(0)
+end
+
+Then /^I should have one tag$/ do
+  expect(Tag.all.size).to eq(1)
+end
+
+Then /^I should have two tags$/ do
+  expect(Tag.all.size).to eq(2)
+end
+
+Given /^tag$/ do
+  FactoryGirl.create(:tag)
+end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -50,6 +50,12 @@ module NavigationHelpers
       backend.new_content_type_path
     when /the edit content type page for "(.*)"$/
       backend.edit_content_type_path(ContentType.find_by(title: $1).id)
+    when /the tags page/
+      backend.tags_path
+    when /the new tag page/
+      backend.new_tag_path
+    when /the edit tag page for "(.*)"$/
+      backend.edit_tag_path(Tag.find_by(name: $1).id)
     when /the news_articles page/
       backend.news_articles_path
     when /the new news_article page/

--- a/features/tags.feature
+++ b/features/tags.feature
@@ -1,0 +1,26 @@
+Feature: Tags
+In order to manage tags
+As an adminuser
+I want to edit, create, view tags
+
+  Scenario: User can view tags page and tag page
+    Given I am authenticated adminuser
+    And tag
+    When I go to the tags page
+    And I should see "tag one"
+
+  Scenario: Adminuser can edit tag
+    Given tag
+    And I am authenticated adminuser
+    When I go to the edit tag page for "tag one"
+    And I fill in "Name" with "tag edited"
+    And I press "SAVE"
+    Then I should see "tag edited"
+
+  Scenario: Adminuser can create tag
+    Given I am authenticated adminuser
+    When I go to the new tag page
+    And I fill in "Name" with "tag new"
+    And I press "SAVE"
+    Then I should have one tag
+    And I should see "tag new"

--- a/spec/backend/controllers/tags_controller_spec.rb
+++ b/spec/backend/controllers/tags_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+module Backend
+  RSpec.describe TagsController, type: :controller do
+    routes { Backend::Engine.routes }
+
+    before :each do
+      @tag         = create(:tag)
+      @adminuser     = create(:user, email: 'admin@sample.com', active: true, role: 'admin', first_name: 'Juanito')
+    end
+
+    let!(:attri) do
+      { name: 'Update content type' }
+    end
+
+    let!(:attri_fail) do
+      { name: '' }
+    end
+
+    context 'For authenticated user' do
+      before :each do
+        sign_in @adminuser
+      end
+
+      it 'GET index returns http success' do
+        process :index
+        expect(response).to be_success
+        expect(response).to have_http_status(200)
+      end
+
+      it 'GET edit returns http success' do
+        process :edit, params: { id: @tag.id }
+        expect(response).to be_success
+        expect(response).to have_http_status(200)
+      end
+
+      it 'Update content type' do
+        process :update, method: :put, params: { id: @tag.id, tag: attri }
+        expect(response).to be_redirect
+        expect(response).to have_http_status(302)
+      end
+
+      render_views
+
+    end
+  end
+end

--- a/spec/factories/tag.rb
+++ b/spec/factories/tag.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :tag do
+    name       'tag one'
+    category Tag::CATEGORIES.first
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -52,6 +52,7 @@ module Account
         Abilities::PublisherUser.any_instance.should_receive(:can).with([:publish, :unpublish, :make_featured, :remove_featured], ::Publication)
         Abilities::PublisherUser.any_instance.should_receive(:can).with(:manage, ::Vacancy)
         Abilities::PublisherUser.any_instance.should_receive(:can).with([:publish, :unpublish], ::Vacancy)
+        Abilities::PublisherUser.any_instance.should_receive(:can).with(:manage, ::Tag)
 
         Abilities::PublisherUser.any_instance.should_receive(:cannot).with(:make_admin, ::User, id: @publisheruser.id)
         Abilities::PublisherUser.any_instance.should_receive(:cannot).with(:make_contributor, ::User, id: @publisheruser.id)


### PR DESCRIPTION
In this PR we bring you:

* tag management using [acts-as-taggable-on](https://github.com/mbleigh/acts-as-taggable-on)
* allows managing a "category" field for tags, so that they can have some organization
* enables tagging of Content (Activity and Publication)
* adds specs and cucumber features

Requires:
`rails db:migrate` to run migrations;

Things to do next on this:

* styling tag field for both Activities and Publications;
* make it possible to select "empty" value when managing tags, for tags without a category (the default). Or set a default of "generic" category.