### PR TITLE
Feature/cms create inline tags

### DIFF
--- a/backend/app/assets/javascripts/backend/views/form_view.js
+++ b/backend/app/assets/javascripts/backend/views/form_view.js
@@ -13,7 +13,8 @@
       adjustableTriggerClass: ".js-adjustable-input",
       mediumEditorTriggerClass: ".js-textarea-editable",
       selectTriggerClass: ".js-select",
-      selectTagsTriggerClass: ".js-select-tags"
+      selectTagsTriggerClass: ".js-select-tags",
+      selectTagsInlineClass: "js-inline-tags"
     },
 
     initialize: function() {
@@ -70,9 +71,17 @@
     },
 
     _loadTaggingSelect: function () {
-      $(this.options.selectTagsTriggerClass).select2({
-        tags: true
-      });
+      _.each($(this.options.selectTagsTriggerClass), function(element) {
+        var params = {
+          tags: true
+        };
+        if(!$(element).hasClass(this.options.selectTagsInlineClass)) {
+          params.createTag = function() {
+            return undefined;
+          };
+        }
+        $(element).select2(params);
+      }.bind(this));
     },
 
     _loadMediaContentSearch: function() {

--- a/backend/app/assets/stylesheets/backend/components/_c-form.scss
+++ b/backend/app/assets/stylesheets/backend/components/_c-form.scss
@@ -207,6 +207,15 @@ $error-red: #ec5c5c;
           .select2-selection__rendered {
             padding: rem(4px) rem(5px) rem(8px) rem(8px);
           }
+
+          .select2-search--inline {
+            height: rem(30px);
+            margin-top: rem(5px);
+            font-family: $font-family-1;
+            font-size: rem(14px);
+            line-height: 2.2;
+            color: $font-color-1;
+          }
         }
       }
 

--- a/backend/app/views/backend/shared/form/_field_tags.html.slim
+++ b/backend/app/views/backend/shared/form/_field_tags.html.slim
@@ -3,4 +3,4 @@
   = form.input :tag_list, collection: collection, label: false,
     as: :collection_select, value_method: :name,
     input_html: {multiple: true,
-    class: 'basic-input text -plain-text -dark js-select-tags'}
+    class: 'basic-input text -plain-text -dark js-select-tags js-inline-tags'}


### PR DESCRIPTION
*Select2 native support for create inline tags.
*Disabling support for other tags who don't need this behaviour (news, publications, etc...)