### PR TITLE
Adds site_sections to hold descriptions for each page

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ First time execute:
 
     rails import:activities
     rails import:rss
+    rails initialize:site_sections
 
 ## OS Sierra
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -6,6 +6,7 @@ class ActivitiesController < ApplicationController
     @activities = Activity.fetch_all(options_filter)
     @content_types = ContentType.by_activity
     @partners = Partner.order(:name)
+    @section = SiteSection.where(section: "activities").first
     respond_to do |format|
       format.html
       format.js

--- a/app/controllers/news_articles_controller.rb
+++ b/app/controllers/news_articles_controller.rb
@@ -4,6 +4,7 @@ class NewsArticlesController < ApplicationController
 
   def index
     @articles = NewsArticle.order(publication_date: :desc)
+    @section = SiteSection.where(section: "activities").first
   end
 
   def show

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -11,6 +11,7 @@ class PublicationsController < ApplicationController
                [Date.today.year]
              end
     @tags = Tag.order(:name)
+    @section = SiteSection.where(section: "activities").first
     respond_to do |format|
       format.html
       format.js

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -6,7 +6,7 @@
       <div class="title-block">
         <h1 class="text -title-library">Activities</h1>
         <div class="text -summary">
-          GRID-Arendal has produced publications, in both printed and electronic formats, on a wide range of issues related to the environment.
+          <%= @section.description %>
         </div>
         <!-- <div class="share">
           <svg class="icon">

--- a/app/views/news_articles/index.html.erb
+++ b/app/views/news_articles/index.html.erb
@@ -6,7 +6,7 @@
       <div class="title-block">
         <h1 class="text -title-library">News</h1>
         <div class="text -summary">
-          GRID-Arendal has produced publications, in both printed and electronic formats, on a wide range of issues related to the environment.
+          <%= @section.description %>
         </div>
         <!-- <div class="share">
           <svg class="icon">

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -6,7 +6,7 @@
       <div class="title-block">
         <h1 class="text -title-library">Publications</h1>
         <div class="text -summary">
-          GRID-Arendal has produced publications, in both printed and electronic formats, on a wide range of issues related to the environment.
+          <%= @section.description %>
         </div>
         <!-- <div class="share">
           <svg class="icon">

--- a/backend/app/controllers/backend/application_controller.rb
+++ b/backend/app/controllers/backend/application_controller.rb
@@ -36,7 +36,9 @@ module Backend
         {name: "Tags", path: tags_path,
           key: "tags", count: Tag.count},
         {name: "Vacancies", path: vacancies_path,
-          key: "vacancies", count: Vacancy.count}
+          key: "vacancies", count: Vacancy.count},
+        {name: "Sections", path: site_sections_path,
+          key: "sections", count: SiteSection.count}
       ]
     end
   end

--- a/backend/app/controllers/backend/site_sections_controller.rb
+++ b/backend/app/controllers/backend/site_sections_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require_dependency 'backend/application_controller'
+
+module Backend
+  class SiteSectionsController < ::Backend::ApplicationController
+    load_and_authorize_resource
+
+    before_action :set_site_section,  except: [:index]
+    before_action :set_site_sections
+
+    def index
+    end
+
+    def edit
+    end
+
+    def update
+      if @site_section.update(site_section_params)
+        redirect_to [:edit, @site_section], notice: 'Section updated'
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @site_section = SiteSection.find(params[:id])
+      if @site_section.destroy
+        redirect_to site_sections_url
+      end
+    end
+
+    private
+
+      def set_site_section
+        @site_section = SiteSection.find(params[:id])
+      end
+
+      def set_site_sections
+        @site_sections = SiteSection.order(:section)
+      end
+
+      def site_section_params
+        params.require(:site_section).permit!
+      end
+  end
+end

--- a/backend/app/models/site_section.rb
+++ b/backend/app/models/site_section.rb
@@ -1,0 +1,6 @@
+class SiteSection < ApplicationRecord
+  SECTIONS = ["home", "activities", "publications", "news", "media_library",
+              "about"]
+
+  validates :section, uniqueness: true
+end

--- a/backend/app/views/backend/site_sections/_form.html.erb
+++ b/backend/app/views/backend/site_sections/_form.html.erb
@@ -1,0 +1,23 @@
+<div class="form_header" data-fields="1">
+  <% if flash[:notice] %>
+    <li><%= flash[:notice] %></li>
+  <% end %>
+  <%= form.label :section %>
+  <%= form.input :section, label: false,
+    input_html: { class: 'text -main-title -dark title js-adjustable-input',
+                  disabled: true} %>
+
+  <svg class="icon">
+    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-edit"></use>
+  </svg>
+
+  <div class="actions">
+    <%= form.button :submit, 'SAVE', class: '-dark' %>
+    <%= link_to "CANCEL", :back, class: 'btn -light' %>
+  </div>
+</div>
+
+<div class="fields">
+  <%= render 'backend/shared/form/field_textarea', form: form,
+    value: :description %>
+</div>

--- a/backend/app/views/backend/site_sections/_site_sections.html.erb
+++ b/backend/app/views/backend/site_sections/_site_sections.html.erb
@@ -1,0 +1,9 @@
+<h2 class="text -main-title -light">Site sections</h2>
+
+<ul class="items-list">
+  <% @site_sections.each do |site_section| %>
+    <%= render 'backend/shared/index_item',
+      item: site_section,
+      title: site_section.section.titleize %>
+  <% end %>
+</ul>

--- a/backend/app/views/backend/site_sections/edit.html.erb
+++ b/backend/app/views/backend/site_sections/edit.html.erb
@@ -1,0 +1,9 @@
+<div class="l-items-index">
+  <%= render 'site_sections', site_sections: @site_sections %>
+</div>
+
+<div class="l-items-detail">
+  <%= simple_form_for @site_section, html: { class: 'c-form' } do |f| %>
+    <%= render 'form', form: f %>
+  <% end %>
+</div>

--- a/backend/app/views/backend/site_sections/index.html.erb
+++ b/backend/app/views/backend/site_sections/index.html.erb
@@ -1,0 +1,7 @@
+<div class="l-items-index">
+  <%= render 'site_sections', site_sections: @site_sections %>
+</div>
+
+<div class="l-items-detail">
+  <%= render 'backend/shared/phrases' %>
+</div>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -26,6 +26,7 @@ Backend::Engine.routes.draw do
 
   resources :partners,       except: :show
   resources :about_sections, except: :show
+  resources :site_sections, except: [:show, :new, :create]
   resources :news_articles,  except: [:show, :new, :create] do
     get :fetch, on: :collection
   end

--- a/db/migrate/20161214235936_create_site_sections.rb
+++ b/db/migrate/20161214235936_create_site_sections.rb
@@ -1,0 +1,10 @@
+class CreateSiteSections < ActiveRecord::Migration[5.0]
+  def change
+    create_table :site_sections do |t|
+      t.string :section
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161214234909) do
+ActiveRecord::Schema.define(version: 20161214235936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -163,6 +163,13 @@ ActiveRecord::Schema.define(version: 20161214234909) do
     t.integer  "publication_id"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
+  end
+
+  create_table "site_sections", force: :cascade do |t|
+    t.string   "section"
+    t.text     "description"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/lib/tasks/site_sections.rake
+++ b/lib/tasks/site_sections.rake
@@ -1,0 +1,11 @@
+namespace :initialize do
+
+  desc "Creates objects for site sections with defauld descriptions"
+  task site_sections: :environment do
+    puts "started with #{SiteSection.count}"
+    SiteSection::SECTIONS.each do |section|
+      SiteSection.find_or_create_by(section: section)
+    end
+    puts "ended with #{SiteSection.count}"
+  end
+end


### PR DESCRIPTION
Run:

`rails initialize:site_sections`

to get the necessary objects. Then they are managed in the back end and will show up in the front end.