### PR TITLE
Creates fields to cache dropbox urls to pictures

### DIFF
--- a/app/views/publications/_publications.html.erb
+++ b/app/views/publications/_publications.html.erb
@@ -2,8 +2,8 @@
   <%= link_to publication_path(publication) do %>
     <div class="item">
       <article class="c-card">
-        <% photo_url = if publication.picture.present?
-                         publication.picture.url(:medium)
+        <% photo_url = if publication.db_medium_picture.present?
+                         publication.db_medium_picture
                        elsif publication.media_content
                          publication.media_content.photo_sizes.where(label: PhotoSize::MEDIUM).first.try(:url)
                        else

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -34,8 +34,8 @@
   <div class="row">
     <div class="small-12 column">
       <%
-        picture_url = if @publication.picture.present?
-                        @publication.picture.url
+        picture_url = if @publication.db_original_picture.present?
+                        @publication.db_original_picture
                       elsif @publication.media_content
                         @publication.media_content.photos.first.photo_sizes.where(label: PhotoSize::LARGE).first.url
                       else
@@ -66,8 +66,8 @@
         <div class="meta">
           <div class="row">
             <div class="small-6 medium-3 large-4 columns">
-              <% if @publication.cover_picture.present? %>
-                <div class="cover" style="<%= "background-image: url('#{@publication.cover_picture.url(:medium)}')" %>"></div>
+              <% if @publication.db_medium_cover_picture.present? %>
+                <div class="cover" style="<%= "background-image: url('#{@publication.db_medium_cover_picture}')" %>"></div>
               <% end %>
             </div>
             <div class="small-6 medium-9 large-8 columns">

--- a/backend/app/models/concerns/attachable.rb
+++ b/backend/app/models/concerns/attachable.rb
@@ -11,7 +11,7 @@ module Attachable
                           storage: :dropbox,
                           dropbox_credentials: Rails.root.join('config/dropbox.yml'),
                           dropbox_options: {
-                            path: proc { |style| "#{Rails.env}/#{self.class.to_s}/#{style}/#{id}_#{picture.original_filename}"},
+                            path: proc { |style| "production/#{self.class.to_s}/#{style}/#{id}_#{picture.original_filename}"},
                             unique_filename: true
                           }
       else
@@ -35,7 +35,7 @@ module Attachable
                           storage: :dropbox,
                           dropbox_credentials: Rails.root.join('config/dropbox.yml'),
                           dropbox_options: {
-                            path: proc { |style| "#{Rails.env}/#{self.class.to_s}/#{style}/#{id}_#{cover_picture.original_filename}"},
+                            path: proc { |style| "production/#{self.class.to_s}/#{style}/#{id}_#{cover_picture.original_filename}"},
                             unique_filename: true
                           }
       else

--- a/db/migrate/20161219113645_add_dropbox_cache_urls_to_contents.rb
+++ b/db/migrate/20161219113645_add_dropbox_cache_urls_to_contents.rb
@@ -1,0 +1,8 @@
+class AddDropboxCacheUrlsToContents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :contents, :db_medium_picture, :string
+    add_column :contents, :db_original_picture, :string
+    add_column :contents, :db_medium_cover_picture, :string
+    add_column :contents, :db_original_cover_picture, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161214235936) do
+ActiveRecord::Schema.define(version: 20161219113645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,9 +58,9 @@ ActiveRecord::Schema.define(version: 20161214235936) do
     t.string   "picture_content_type"
     t.integer  "picture_file_size"
     t.datetime "picture_updated_at"
+    t.boolean  "is_featured"
     t.integer  "project_number"
     t.text     "short_description"
-    t.boolean  "is_featured"
     t.date     "content_date"
     t.integer  "content_type_id"
     t.integer  "media_content_id"
@@ -69,6 +69,10 @@ ActiveRecord::Schema.define(version: 20161214235936) do
     t.string   "cover_picture_content_type"
     t.integer  "cover_picture_file_size"
     t.datetime "cover_picture_update_at"
+    t.string   "db_medium_picture"
+    t.string   "db_original_picture"
+    t.string   "db_medium_cover_picture"
+    t.string   "db_original_cover_picture"
   end
 
   create_table "documents", force: :cascade do |t|
@@ -226,6 +230,10 @@ ActiveRecord::Schema.define(version: 20161214235936) do
     t.string   "avatar_content_type"
     t.integer  "avatar_file_size"
     t.datetime "avatar_updated_at"
+    t.string   "thumbnail_file_name"
+    t.string   "thumbnail_content_type"
+    t.integer  "thumbnail_file_size"
+    t.datetime "thumbnail_updated_at"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end

--- a/lib/tasks/dropbox.rake
+++ b/lib/tasks/dropbox.rake
@@ -1,0 +1,16 @@
+namespace :dropbox do
+
+  desc 'caches dropbox urls'
+  task cache_urls: :environment do
+    Publication.where.not(picture_file_name: nil).each do |p|
+      p.db_medium_picture = p.picture.url(:medium)
+      p.db_original_picture = p.picture.url(:original)
+      p.save
+    end
+    Publication.where.not(cover_picture_file_name: nil).each do |p|
+      p.db_medium_cover_picture = p.cover_picture.url(:medium)
+      p.db_original_cover_picture = p.cover_picture.url(:original)
+      p.save
+    end
+  end
+end


### PR DESCRIPTION
Requires:

`rails db:migrate`

And then:

`rake dropbox:cache_urls` will create the caches.

Fixes issue with slow page loads.