### PR TITLE
Don't run masonry again if it's already set

### DIFF
--- a/app/assets/javascripts/controllers/activities_controller.js
+++ b/app/assets/javascripts/controllers/activities_controller.js
@@ -7,9 +7,11 @@
   App.Controller.Activities = App.Controller.Page.extend({
 
     index: function(params) {
-      new App.View.Masonry({
-        el: '.masonry-layout'
-      });
+      if($('.masonry-layout').find('.masonry-column').length === 0) {
+        new App.View.Masonry({
+          el: '.masonry-layout'
+        });
+      }
       this.filtersView = new App.View.MediaFilters({
         callback: this._filter.bind(this)
       });

--- a/app/assets/javascripts/controllers/media_controller.js
+++ b/app/assets/javascripts/controllers/media_controller.js
@@ -7,9 +7,11 @@
   App.Controller.Media = App.Controller.Page.extend({
 
     index: function(params) {
-      var masonryView = new App.View.Masonry({
-        el: '.masonry-layout'
-      });
+      if($('.masonry-layout').find('.masonry-column').length === 0) {
+        var masonryView = new App.View.Masonry({
+          el: '.masonry-layout'
+        });
+      }
       var filtersView = new App.View.MediaFilters({
         options: {
           filters: [

--- a/app/assets/javascripts/controllers/news_controller.js
+++ b/app/assets/javascripts/controllers/news_controller.js
@@ -7,9 +7,11 @@
   App.Controller.News = App.Controller.Page.extend({
 
     index: function(params) {
-      var masonryView = new App.View.Masonry({
-        el: '.masonry-layout'
-      });
+      if($('.masonry-layout').find('.masonry-column').length === 0) {
+        new App.View.Masonry({
+          el: '.masonry-layout'
+        });
+      }
     },
 
     show: function(params) { },

--- a/app/assets/javascripts/controllers/publications_controller.js
+++ b/app/assets/javascripts/controllers/publications_controller.js
@@ -7,9 +7,11 @@
   App.Controller.Publications = App.Controller.Page.extend({
 
     index: function(params) {
-      new App.View.Masonry({
-        el: '.masonry-layout'
-      });
+      if($('.masonry-layout').find('.masonry-column').length === 0) {
+        new App.View.Masonry({
+          el: '.masonry-layout'
+        });
+      }
       this.filtersView = new App.View.MediaFilters({
         callback: this._filter.bind(this)
       });


### PR DESCRIPTION
Avoids the issue of going to an index page, then to a show page, then back to the index page and have the masonry look weird, like this:

<img width="1278" alt="screen shot 2016-12-20 at 10 46 56" src="https://cloud.githubusercontent.com/assets/10764/21347699/a62dc4b2-c6a1-11e6-85cf-88636f60a43f.png">
