### PR TITLE
Remove picture from contents

### DIFF
--- a/backend/app/models/content.rb
+++ b/backend/app/models/content.rb
@@ -22,7 +22,6 @@ class Content < ApplicationRecord
   include Publishable
   include Sanitizable
   include Featurable
-  include Attachable::Picture
 
   acts_as_taggable
 

--- a/db/migrate/20170104114932_remove_picture_from_contents.rb
+++ b/db/migrate/20170104114932_remove_picture_from_contents.rb
@@ -1,0 +1,8 @@
+class RemovePictureFromContents < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :contents, :picture_file_name, :string
+    remove_column :contents, :picture_content_type, :string
+    remove_column :contents, :picture_file_size, :integer
+    remove_column :contents, :picture_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170103124733) do
+ActiveRecord::Schema.define(version: 20170104114932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,10 +54,6 @@ ActiveRecord::Schema.define(version: 20170103124733) do
     t.string   "story_map_url"
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
-    t.string   "picture_file_name"
-    t.string   "picture_content_type"
-    t.integer  "picture_file_size"
-    t.datetime "picture_updated_at"
     t.boolean  "is_featured"
     t.integer  "project_number"
     t.text     "short_description"


### PR DESCRIPTION
We started using s_picture as the picture field on Amazon. This PR removes the old picture field.

Later I'll add another longer PR to replace the other occurrences of picture from other models to use Amazon as well. And then we can rename s_picture to picture.

Requires:

`rails db:migrate`