### PR TITLE
feature/media library vertical photos

### DIFF
--- a/app/assets/stylesheets/components/_c-article-image.scss
+++ b/app/assets/stylesheets/components/_c-article-image.scss
@@ -1,10 +1,15 @@
 .c-article-image {
+  background-color: rgba($color-2, 0.05);
   background-position: center center;
   background-repeat: no-repeat;
   background-size: cover;
   height: rem(580px);
   z-index: 10;
   display: none;
+
+  &.-vertical {
+    background-size: contain;
+  }
 
   @media screen and (min-width: $screen-m) {
     display: block;

--- a/app/views/media_library/show.html.erb
+++ b/app/views/media_library/show.html.erb
@@ -1,13 +1,16 @@
 <%
-    picture_url = case @media_content.type
-                  when MediaContent::TYPE_ALBUM
-                    photo = @media_content.photos.first
-                    photo && photo.photo_sizes.where(label: PhotoSize::LARGE).first.try(:url)
-                  when MediaContent::TYPE_PHOTO
-                    @media_content.photo_sizes.where(label: PhotoSize::LARGE).first.try(:url)
-                  else
-                    nil
-                  end
+  is_vertical = false
+  picture_url = case @media_content.type
+                when MediaContent::TYPE_ALBUM
+                  photo = @media_content.photos.first
+                  is_vertical = photo.photo_sizes.where(label: PhotoSize::LARGE).first.is_vertical
+                  photo && photo.photo_sizes.where(label: PhotoSize::LARGE).first.try(:url)
+                when MediaContent::TYPE_PHOTO
+                  is_vertical = @media_content.photo_sizes.where(label: PhotoSize::LARGE).first.is_vertical
+                  @media_content.photo_sizes.where(label: PhotoSize::LARGE).first.try(:url)
+                else
+                  nil
+                end
 %>
 <div class="l-header-single -media-library">
   <div class="overlay"></div>
@@ -29,7 +32,7 @@
 
   <div class="row">
     <div class="small-12 column">
-      <div class="c-article-image" style="background-image: url('<%= picture_url %>');"></div>
+      <div class="c-article-image <% if is_vertical %>-vertical<% end %>" style="background-image: url('<%= picture_url %>');"></div>
     </div>
   </div>
 

--- a/backend/app/models/photo_size.rb
+++ b/backend/app/models/photo_size.rb
@@ -7,4 +7,8 @@ class PhotoSize < ApplicationRecord
   SMALL = "Small"
 
   LABELS = [ORIGINAL, LARGE, MEDIUM, SMALL]
+
+  def is_vertical
+    return ((self.height / 100) * 70) >= self.width
+  end
 end


### PR DESCRIPTION
* Support vertical photos in the media library show page

Example: http://localhost:3000/media-library/1912
![gridarendal1](https://cloud.githubusercontent.com/assets/1432880/21648850/bd5cbcb0-d29f-11e6-9cd4-9e7e01e7a46a.png)

vs

![gridarendal2](https://cloud.githubusercontent.com/assets/1432880/21648853/c6461bdc-d29f-11e6-898e-0d42c1de1cfa.png)
