### PR TITLE
Feature/move from dropbox to amazon

### DIFF
--- a/app/views/home/_event_modal.html.erb
+++ b/app/views/home/_event_modal.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="small-12 columns">
       <div class="c-events-modal">
-        <div class="event-container" style="background-image: url(<%= @event.background_image %>);">
+        <div class="event-container" style="background-image: url(<%= @event.s_background_image %>);">
           <div class="js-btn-events-modal">
             <svg class="icon icon-share">
               <use xlink:href="#icon-close"></use>

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -56,8 +56,8 @@
         <div class="meta">
           <div class="row">
             <div class="small-6 medium-3 large-4 columns">
-              <% if @publication.cover_picture.exists? %>
-                <div class="cover" style="<%= "background-image: url('#{@publication.cover_picture.url(:medium)}')" %>"></div>
+              <% if @publication.s_cover_picture.exists? %>
+                <div class="cover" style="<%= "background-image: url('#{@publication.s_cover_picture.url(:medium)}')" %>"></div>
               <% end %>
             </div>
             <div class="small-6 medium-9 large-8 columns">

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -1,5 +1,5 @@
-<% picture_url = if @publication.s_picture.exists?
-                  @publication.s_picture.url(:original)
+<% picture_url = if @publication.picture.exists?
+                  @publication.picture.url(:original)
                 elsif @publication.media_content
                   photo = if @publication.media_content.is_a?(Photo)
                             @publication.media_content

--- a/app/views/shared/_content_card.html.erb
+++ b/app/views/shared/_content_card.html.erb
@@ -1,8 +1,8 @@
 <div class="item js_slide slide">
   <%= link_to item do %>
     <article class="c-card" data-card-type="<%= item.type.downcase %>">
-      <% photo_url = if item.s_picture_file_name && item.s_picture.exists?
-                       item.s_picture.url(:medium)
+      <% photo_url = if item.picture_file_name && item.picture.exists?
+                       item.picture.url(:medium)
                      elsif item.media_content
                        item.media_content.photo_sizes.where(label: PhotoSize::MEDIUM).first.try(:url)
                      else

--- a/app/views/shared/_partners.html.erb
+++ b/app/views/shared/_partners.html.erb
@@ -17,7 +17,7 @@
       <div class="logos">
         <% partners.each do |partner| %>
           <%= link_to partner.web_url || "#" do %>
-            <span><img src="<%= partner.logo.exists? ? partner.logo.url : asset_path('original/missing2.png') %>"></span>
+            <span><img src="<%= partner.s_logo.exists? ? partner.s_logo.url : asset_path('original/missing2.png') %>"></span>
           <% end %>
         <% end %>
       </div>

--- a/app/views/shared/_user.html.erb
+++ b/app/views/shared/_user.html.erb
@@ -1,5 +1,5 @@
-<% avatar_url = if user.avatar.exists?
-                  user.avatar(:medium)
+<% avatar_url = if user.s_avatar.exists?
+                  user.s_avatar(:medium)
                 else
                   asset_path('original/missing2.png')
                 end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
 <ul>
   <% @users.each do |user| %>
     <li>
-      <%= image_tag(user.avatar(:medium)) %>
+      <%= image_tag(user.s_avatar(:medium)) %>
       <%= link_to user.display_name, staff_path(user) %>
       <%= user.current_position %>
     </li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
-<% avatar_url = if @user.avatar.exists?
-                  @user.avatar(:medium)
+<% avatar_url = if @user.s_avatar.exists?
+                  @user.s_avatar(:medium)
                 else
                   asset_path('original/missing2.png')
                 end %>

--- a/backend/app/models/concerns/attachable.rb
+++ b/backend/app/models/concerns/attachable.rb
@@ -75,6 +75,33 @@ module Attachable
     end
   end
 
+  module SLogo
+    extend ActiveSupport::Concern
+
+    included do
+      if ENV['AWS_ACCESS_KEY_ID'].present?
+        has_attached_file :s_logo,
+                          styles: { medium: '300x300>', thumb: '100x100>' },
+                          default_url: '/assets/:style/missing2.png',
+                          storage: :s3,
+                          s3_credentials: {
+                            bucket: ENV['S3_BUCKET_NAME'],
+                            access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+                            secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+                            s3_region: ENV['AWS_REGION'],
+                          },
+                          url: ':s3_domain_url',
+                          path: "#{Rails.env}/:class/:s_logo/:id/:style/:basename.:extension"
+      else
+        has_attached_file :s_logo, styles: { medium: '300x300>', thumb: '100x100>' },
+                                 default_url: '/assets/:style/missing2.png'
+      end
+
+      validates_attachment_content_type :s_logo, content_type: /\Aimage/
+      validates_attachment_file_name :s_logo, matches: [/png\Z/, /jpe?g\Z/,/gif\Z/,/PNG\Z/, /JPE?G\Z/,/GIF\Z/]
+    end
+  end
+
   module BackgroundImage
     extend ActiveSupport::Concern
 

--- a/backend/app/models/concerns/attachable.rb
+++ b/backend/app/models/concerns/attachable.rb
@@ -51,6 +51,33 @@ module Attachable
     end
   end
 
+  module SCoverPicture
+    extend ActiveSupport::Concern
+
+    included do
+      if ENV['DROPBOX_APP_KEY'].present?
+        has_attached_file :s_cover_picture,
+                          styles: { medium: '300x300>', thumb: '100x100>' },
+                          default_url: '/assets/:style/missing2.png',
+                          storage: :s3,
+                          s3_credentials: {
+                            bucket: ENV['S3_BUCKET_NAME'],
+                            access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+                            secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+                            s3_region: ENV['AWS_REGION'],
+                          },
+                          url: ':s3_domain_url',
+                          path: "#{Rails.env}/:class/:s_cover_picture/:id/:style/:basename.:extension"
+      else
+        has_attached_file :s_cover_picture, styles: { medium: '300x300>', thumb: '100x100>' },
+                          default_url: '/assets/:style/missing2.png'
+      end
+
+      validates_attachment_content_type :s_cover_picture, content_type: /\Aimage/
+      validates_attachment_file_name :s_cover_picture, matches: [/png\Z/, /jpe?g\Z/,/gif\Z/,/PNG\Z/, /JPE?G\Z/,/GIF\Z/]
+    end
+  end
+
   module Logo
     extend ActiveSupport::Concern
 

--- a/backend/app/models/concerns/attachable.rb
+++ b/backend/app/models/concerns/attachable.rb
@@ -4,32 +4,8 @@ module Attachable
     extend ActiveSupport::Concern
 
     included do
-      if ENV['DROPBOX_APP_KEY'].present?
-        has_attached_file :picture,
-                          styles: { medium: '300x300>', thumb: '100x100>' },
-                          default_url: '/assets/:style/missing2.png',
-                          storage: :dropbox,
-                          dropbox_credentials: Rails.root.join('config/dropbox.yml'),
-                          dropbox_options: {
-                            path: proc { |style| "#{Rails.env}/#{self.class.to_s}/#{style}/#{id}_#{picture.original_filename}"},
-                            unique_filename: true
-                          }
-      else
-        has_attached_file :picture, styles: { medium: '300x300>', thumb: '100x100>' },
-                                    default_url: '/assets/:style/missing2.png'
-      end
-
-      validates_attachment_content_type :picture, content_type: /\Aimage/
-      validates_attachment_file_name :picture, matches: [/png\Z/, /jpe?g\Z/,/gif\Z/,/PNG\Z/, /JPE?G\Z/,/GIF\Z/]
-    end
-  end
-
-  module SPicture
-    extend ActiveSupport::Concern
-
-    included do
       if ENV['AWS_ACCESS_KEY_ID'].present?
-        has_attached_file :s_picture,
+        has_attached_file :picture,
                           styles: { medium: '300x300>', thumb: '100x100>' },
                           default_url: '/assets/:style/missing2.png',
                           storage: :s3,
@@ -42,12 +18,12 @@ module Attachable
                           url: ':s3_domain_url',
                           path: "#{Rails.env}/:class/:s_picture/:id/:style/:basename.:extension"
       else
-        has_attached_file :s_picture, styles: { medium: '300x300>', thumb: '100x100>' },
+        has_attached_file :picture, styles: { medium: '300x300>', thumb: '100x100>' },
                                     default_url: '/assets/:style/missing2.png'
       end
 
-      validates_attachment_content_type :s_picture, content_type: /\Aimage/
-      validates_attachment_file_name :s_picture, matches: [/png\Z/, /jpe?g\Z/,/gif\Z/,/PNG\Z/, /JPE?G\Z/,/GIF\Z/]
+      validates_attachment_content_type :picture, content_type: /\Aimage/
+      validates_attachment_file_name :picture, matches: [/png\Z/, /jpe?g\Z/,/gif\Z/,/PNG\Z/, /JPE?G\Z/,/GIF\Z/]
     end
   end
 

--- a/backend/app/models/concerns/attachable.rb
+++ b/backend/app/models/concerns/attachable.rb
@@ -153,6 +153,33 @@ module Attachable
     end
   end
 
+  module SBackgroundImage
+    extend ActiveSupport::Concern
+
+    included do
+      if ENV['AWS_ACCESS_KEY_ID'].present?
+        has_attached_file :s_background_image,
+                          styles: { medium: '300x300>', thumb: '100x100>' },
+                          default_url: '/assets/:style/missing2.png',
+                          storage: :s3,
+                          s3_credentials: {
+                            bucket: ENV['S3_BUCKET_NAME'],
+                            access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+                            secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+                            s3_region: ENV['AWS_REGION'],
+                          },
+                          url: ':s3_domain_url',
+                          path: "#{Rails.env}/:class/:s_background_image/:id/:style/:basename.:extension"
+      else
+        has_attached_file :s_background_image, styles: { medium: '300x300>', thumb: '100x100>' },
+                                             default_url: '/assets/:style/missing2.png'
+      end
+
+      validates_attachment_content_type :s_background_image, content_type: /\Aimage/
+      validates_attachment_file_name :s_background_image, matches: [/png\Z/, /jpe?g\Z/,/gif\Z/,/PNG\Z/, /JPE?G\Z/,/GIF\Z/]
+    end
+  end
+
   module Avatar
     extend ActiveSupport::Concern
 

--- a/backend/app/models/concerns/attachable.rb
+++ b/backend/app/models/concerns/attachable.rb
@@ -55,7 +55,7 @@ module Attachable
     extend ActiveSupport::Concern
 
     included do
-      if ENV['DROPBOX_APP_KEY'].present?
+      if ENV['AWS_ACCESS_KEY_ID'].present?
         has_attached_file :s_cover_picture,
                           styles: { medium: '300x300>', thumb: '100x100>' },
                           default_url: '/assets/:style/missing2.png',
@@ -177,6 +177,33 @@ module Attachable
     end
   end
 
+  module SAvatar
+    extend ActiveSupport::Concern
+
+    included do
+      if ENV['AWS_ACCESS_KEY_ID'].present?
+        has_attached_file :s_avatar,
+                          styles: { medium: '300x300>', thumb: '100x100>' },
+                          default_url: '/assets/:style/missing2.png',
+                          storage: :s3,
+                          s3_credentials: {
+                            bucket: ENV['S3_BUCKET_NAME'],
+                            access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+                            secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+                            s3_region: ENV['AWS_REGION'],
+                          },
+                          url: ':s3_domain_url',
+                          path: "#{Rails.env}/:class/:s_avatar/:id/:style/:basename.:extension"
+      else
+        has_attached_file :s_avatar, styles: { medium: '300x300>', thumb: '100x100>' },
+                                    default_url: '/assets/:style/missing2.png'
+      end
+
+      validates_attachment_content_type :s_avatar, content_type: /\Aimage/
+      validates_attachment_file_name :s_avatar, matches: [/png\Z/, /jpe?g\Z/,/gif\Z/,/PNG\Z/, /JPE?G\Z/,/GIF\Z/]
+    end
+  end
+
   module Thumbnail
     extend ActiveSupport::Concern
 
@@ -198,6 +225,33 @@ module Attachable
 
       validates_attachment_content_type :thumbnail, content_type: /\Aimage/
       validates_attachment_file_name :thumbnail, matches: [/png\Z/, /jpe?g\Z/,/gif\Z/,/PNG\Z/, /JPE?G\Z/,/GIF\Z/]
+    end
+  end
+
+  module SThumbnail
+    extend ActiveSupport::Concern
+
+    included do
+      if ENV['AWS_ACCESS_KEY_ID'].present?
+        has_attached_file :s_thumbnail,
+                          styles: { medium: '300x300>', thumb: '100x100>' },
+                          default_url: '/assets/:style/missing2.png',
+                          storage: :s3,
+                          s3_credentials: {
+                            bucket: ENV['S3_BUCKET_NAME'],
+                            access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+                            secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+                            s3_region: ENV['AWS_REGION'],
+                          },
+                          url: ':s3_domain_url',
+                          path: "#{Rails.env}/:class/:s_thumbnail/:id/:style/:basename.:extension"
+      else
+        has_attached_file :s_thumbnail, styles: { medium: '300x300>', thumb: '100x100>' },
+                                   default_url: '/assets/:style/missing2.png'
+      end
+
+      validates_attachment_content_type :s_thumbnail, content_type: /\Aimage/
+      validates_attachment_file_name :s_thumbnail, matches: [/png\Z/, /jpe?g\Z/,/gif\Z/,/PNG\Z/, /JPE?G\Z/,/GIF\Z/]
     end
   end
 

--- a/backend/app/models/event.rb
+++ b/backend/app/models/event.rb
@@ -25,6 +25,7 @@ class Event < ApplicationRecord
   include Activable
   include Sanitizable
   include Attachable::BackgroundImage
+  include Attachable::SBackgroundImage
 
   has_many :event_partners
   has_many :partners, through: :event_partners

--- a/backend/app/models/partner.rb
+++ b/backend/app/models/partner.rb
@@ -18,6 +18,7 @@
 class Partner < ApplicationRecord
   include Sanitizable
   include Attachable::Logo
+  include Attachable::SLogo
 
   has_many :events
   has_many :content_partners, dependent: :destroy

--- a/backend/app/models/publication.rb
+++ b/backend/app/models/publication.rb
@@ -20,6 +20,7 @@
 
 class Publication < Content
   include Attachable::CoverPicture
+  include Attachable::SCoverPicture
   include Attachable::Picture
   acts_as_taggable
 

--- a/backend/app/models/publication.rb
+++ b/backend/app/models/publication.rb
@@ -20,7 +20,7 @@
 
 class Publication < Content
   include Attachable::CoverPicture
-  include Attachable::SPicture
+  include Attachable::Picture
   acts_as_taggable
 
   has_many :related_contents

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -55,7 +55,9 @@ class User < ApplicationRecord
   include Sanitizable
   include Display
   include Attachable::Avatar
+  include Attachable::SAvatar
   include Attachable::Thumbnail
+  include Attachable::SThumbnail
 
   before_update :deactivate_account, if: 'deactivated? && active_changed?'
   before_update :activate_account,   if: 'activated? && active_changed?'

--- a/backend/app/views/backend/events/_form.html.erb
+++ b/backend/app/views/backend/events/_form.html.erb
@@ -4,7 +4,7 @@
 <div class="fields">
 
   <%= render 'backend/shared/form/field_upload_img', form: form,
-    value: :background_image, label_txt: 'Background image',
+    value: :s_background_image, label_txt: 'Background image',
     have_picture: have_picture, picture_url: picture_url %>
 
   <%= render 'backend/shared/form/field_input', form: form, value: :web_url %>

--- a/backend/app/views/backend/events/edit.html.erb
+++ b/backend/app/views/backend/events/edit.html.erb
@@ -7,7 +7,7 @@
     <%= render 'form',
       form: f,
       partners: @partners,
-      have_picture: @event.background_image_file_name ? true : false,
-      picture_url: @event.background_image %>
+      have_picture: @event.s_background_image_file_name ? true : false,
+      picture_url: @event.s_background_image %>
   <% end %>
 </div>

--- a/backend/app/views/backend/partners/_form.html.erb
+++ b/backend/app/views/backend/partners/_form.html.erb
@@ -2,7 +2,7 @@
   inputs: [{value: :name, title_placeholder: 'Partner name'}] %>
 
 <div class="fields">
-  <%= render 'backend/shared/form/field_upload_img', form: form, value: :logo,
+  <%= render 'backend/shared/form/field_upload_img', form: form, value: :s_logo,
     label_txt: 'Logo', have_picture: have_logo, picture_url: logo_url %>
 
   <%= render 'backend/shared/form/field_input', form: form, value: :web_url %>

--- a/backend/app/views/backend/partners/edit.html.erb
+++ b/backend/app/views/backend/partners/edit.html.erb
@@ -6,7 +6,7 @@
   <%= simple_form_for @partner, html: { class: 'c-form' } do |f| %>
     <%= render 'form',
       form: f,
-      have_logo: @partner.logo_file_name ? true : false,
-      logo_url: @partner.logo %>
+      have_logo: @partner.s_logo_file_name ? true : false,
+      logo_url: @partner.s_logo %>
   <% end %>
 </div>

--- a/backend/app/views/backend/publications/_form.html.erb
+++ b/backend/app/views/backend/publications/_form.html.erb
@@ -8,7 +8,7 @@
 
   <%= render 'backend/shared/form/field_tags', form: form, collection: tags %>
 
-  <%= render 'backend/shared/form/field_upload_img', form: form, value: :s_picture, field_class: '-half',
+  <%= render 'backend/shared/form/field_upload_img', form: form, value: :picture, field_class: '-half',
     label_txt: 'Background picture', have_picture: have_picture, picture_url: picture_url %>
 
   <%= render 'backend/shared/form/field_photos', form: form, value: :media_content_id, label_txt: ' ',

--- a/backend/app/views/backend/publications/_form.html.erb
+++ b/backend/app/views/backend/publications/_form.html.erb
@@ -14,7 +14,7 @@
   <%= render 'backend/shared/form/field_photos', form: form, value: :media_content_id, label_txt: ' ',
     field_class: '-half', photos: photos, selected_id: media_content_id, with_search: true, js_trigger_class: 'js-select-photo' %>
 
-  <%= render 'backend/shared/form/field_upload_img', form: form, value: :cover_picture, field_class: '-half',
+  <%= render 'backend/shared/form/field_upload_img', form: form, value: :s_cover_picture, field_class: '-half',
     label_txt: 'Publication cover', have_picture: have_cover_picture,
     picture_url: cover_picture_url %>
 

--- a/backend/app/views/backend/publications/edit.html.erb
+++ b/backend/app/views/backend/publications/edit.html.erb
@@ -14,8 +14,8 @@
       news_articles: @news_articles,
       tags: @tags,
       photos: @photos,
-      have_cover_picture: @publication.cover_picture.exists?,
-      cover_picture_url: (@publication.cover_picture.exists? ? @publication.cover_picture : nil),
+      have_cover_picture: @publication.s_cover_picture.exists?,
+      cover_picture_url: (@publication.s_cover_picture.exists? ? @publication.s_cover_picture : nil),
       have_picture: @publication.picture.present?,
       picture_url: @publication.picture.present? ? @publication.picture : nil,
       media_content_id: @publication.media_content_id %>

--- a/backend/app/views/backend/publications/edit.html.erb
+++ b/backend/app/views/backend/publications/edit.html.erb
@@ -16,8 +16,8 @@
       photos: @photos,
       have_cover_picture: @publication.cover_picture.exists?,
       cover_picture_url: (@publication.cover_picture.exists? ? @publication.cover_picture : nil),
-      have_picture: @publication.s_picture.present?,
-      picture_url: @publication.s_picture.present? ? @publication.s_picture : nil,
+      have_picture: @publication.picture.present?,
+      picture_url: @publication.picture.present? ? @publication.picture : nil,
       media_content_id: @publication.media_content_id %>
   <% end %>
 </div>

--- a/backend/app/views/backend/shared/_nav_bar.html.erb
+++ b/backend/app/views/backend/shared/_nav_bar.html.erb
@@ -1,7 +1,7 @@
 <ul class="basic-nav">
   <% if user_signed_in? %>
-    <% avatar_url = if current_user.avatar.exists?
-                      current_user.avatar(:medium)
+    <% avatar_url = if current_user.s_avatar.exists?
+                      current_user.s_avatar(:medium)
                     else
                       asset_path('original/missing2.png')
                     end %>

--- a/backend/app/views/backend/users/_form.html.slim
+++ b/backend/app/views/backend/users/_form.html.slim
@@ -4,11 +4,11 @@ div.fields
 
   = render 'backend/shared/form/field_input', form: form, value: :email, required: true
 
-  = render 'backend/shared/form/field_upload_img', form: form, value: :avatar,
+  = render 'backend/shared/form/field_upload_img', form: form, value: :s_avatar,
     label_txt: 'Profile photo', have_picture: have_picture,
     picture_url: picture_url
 
-  = render 'backend/shared/form/field_upload_img', form: form, value: :thumbnail,
+  = render 'backend/shared/form/field_upload_img', form: form, value: :s_thumbnail,
     label_txt: 'Thumbnail', have_picture: have_thumbnail,
     picture_url: thumbnail_url
 

--- a/backend/app/views/backend/users/edit.html.erb
+++ b/backend/app/views/backend/users/edit.html.erb
@@ -7,10 +7,10 @@
     <%= render 'form',
       form: f,
       user_roles: @user_roles,
-      have_picture: @user.avatar_file_name ? true : false,
-      have_thumbnail: @user.thumbnail_file_name ? true : false,
-      picture_url: @user.avatar,
-      thumbnail_url: @user.thumbnail
+      have_picture: @user.s_avatar_file_name ? true : false,
+      have_thumbnail: @user.s_thumbnail_file_name ? true : false,
+      picture_url: @user.s_avatar,
+      thumbnail_url: @user.s_thumbnail
     %>
   <% end %>
 </div>

--- a/backend/app/views/backend/users/show.html.erb
+++ b/backend/app/views/backend/users/show.html.erb
@@ -3,7 +3,7 @@
   <p><%= " (admin)"   if @user.admin? %></p>
   <p><%= " (publisher)" if @user.publisher? %></p>
 
-  <%= image_tag @user.avatar.url(:thumb) %>
+  <%= image_tag @user.s_avatar.url(:thumb) %>
 
   <% if (can? :make_contributor, @user) && (@user.admin? || @user.publisher?) %>
     <%= link_to 'Make contributor', make_contributor_user_path(@user), method: :patch %>

--- a/db/migrate/20170105105906_rename_s_picture_to_picture_in_contents.rb
+++ b/db/migrate/20170105105906_rename_s_picture_to_picture_in_contents.rb
@@ -1,0 +1,8 @@
+class RenameSPictureToPictureInContents < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :contents, :s_picture_file_name, :picture_file_name
+    rename_column :contents, :s_picture_content_type, :picture_content_type
+    rename_column :contents, :s_picture_file_size, :picture_file_size
+    rename_column :contents, :s_picture_updated_at, :picture_updated_at
+  end
+end

--- a/db/migrate/20170105112516_add_fields_for_logo_in_amazon_for_partners.rb
+++ b/db/migrate/20170105112516_add_fields_for_logo_in_amazon_for_partners.rb
@@ -1,0 +1,8 @@
+class AddFieldsForLogoInAmazonForPartners < ActiveRecord::Migration[5.0]
+  def change
+    add_column :partners, :s_logo_file_name, :string
+    add_column :partners, :s_logo_content_type, :string
+    add_column :partners, :s_logo_file_size, :integer
+    add_column :partners, :s_logo_updated_at, :datetime
+  end
+end

--- a/db/migrate/20170105113735_add_fields_for_cover_picture_in_amazon_for_contents.rb
+++ b/db/migrate/20170105113735_add_fields_for_cover_picture_in_amazon_for_contents.rb
@@ -1,0 +1,8 @@
+class AddFieldsForCoverPictureInAmazonForContents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :contents, :s_cover_picture_file_name, :string
+    add_column :contents, :s_cover_picture_content_type, :string
+    add_column :contents, :s_cover_picture_file_size, :integer
+    add_column :contents, :s_cover_picture_updated_at, :datetime
+  end
+end

--- a/db/migrate/20170105121009_add_amazon_files_fields_for_users.rb
+++ b/db/migrate/20170105121009_add_amazon_files_fields_for_users.rb
@@ -1,0 +1,12 @@
+class AddAmazonFilesFieldsForUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :s_avatar_file_name, :string
+    add_column :users, :s_avatar_content_type, :string
+    add_column :users, :s_avatar_file_size, :integer
+    add_column :users, :s_avatar_updated_at, :datetime
+    add_column :users, :s_thumbnail_file_name, :string
+    add_column :users, :s_thumbnail_content_type, :string
+    add_column :users, :s_thumbnail_file_size, :integer
+    add_column :users, :s_thumbnail_updated_at, :datetime
+  end
+end

--- a/db/migrate/20170105122805_add_amazon_image_for_events.rb
+++ b/db/migrate/20170105122805_add_amazon_image_for_events.rb
@@ -1,0 +1,8 @@
+class AddAmazonImageForEvents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :events, :s_background_image_file_name, :string
+    add_column :events, :s_background_image_content_type, :string
+    add_column :events, :s_background_image_file_size, :integer
+    add_column :events, :s_background_image_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170104114932) do
+ActiveRecord::Schema.define(version: 20170105105906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,10 +65,10 @@ ActiveRecord::Schema.define(version: 20170104114932) do
     t.string   "cover_picture_content_type"
     t.integer  "cover_picture_file_size"
     t.datetime "cover_picture_update_at"
-    t.string   "s_picture_file_name"
-    t.string   "s_picture_content_type"
-    t.integer  "s_picture_file_size"
-    t.datetime "s_picture_updated_at"
+    t.string   "picture_file_name"
+    t.string   "picture_content_type"
+    t.integer  "picture_file_size"
+    t.datetime "picture_updated_at"
   end
 
   create_table "documents", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170105105906) do
+ActiveRecord::Schema.define(version: 20170105113735) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,8 +52,8 @@ ActiveRecord::Schema.define(version: 20170105105906) do
     t.boolean  "is_published"
     t.integer  "position"
     t.string   "story_map_url"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
     t.boolean  "is_featured"
     t.integer  "project_number"
     t.text     "short_description"
@@ -155,12 +155,16 @@ ActiveRecord::Schema.define(version: 20170105105906) do
     t.string   "name"
     t.string   "web_url"
     t.text     "description"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
     t.string   "logo_file_name"
     t.string   "logo_content_type"
     t.integer  "logo_file_size"
     t.datetime "logo_updated_at"
+    t.string   "s_logo_file_name"
+    t.string   "s_logo_content_type"
+    t.integer  "s_logo_file_size"
+    t.datetime "s_logo_updated_at"
   end
 
   create_table "photo_sizes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170105113735) do
+ActiveRecord::Schema.define(version: 20170105121009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -221,28 +221,28 @@ ActiveRecord::Schema.define(version: 20170105113735) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "",    null: false
-    t.string   "encrypted_password",     default: "",    null: false
+    t.string   "email",                    default: "",    null: false
+    t.string   "encrypted_password",       default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,     null: false
+    t.integer  "sign_in_count",            default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
     t.string   "first_name"
     t.string   "last_name"
     t.string   "organization"
     t.string   "current_position"
     t.string   "web_url"
-    t.boolean  "active",                 default: false, null: false
+    t.boolean  "active",                   default: false, null: false
     t.datetime "deactivated_at"
-    t.integer  "role",                   default: 0,     null: false, comment: "User role { contributor: 0, publisher: 1, admin: 2 }"
+    t.integer  "role",                     default: 0,     null: false, comment: "User role { contributor: 0, publisher: 1, admin: 2 }"
     t.datetime "locked_at"
-    t.integer  "failed_attempts",        default: 0,     null: false
+    t.integer  "failed_attempts",          default: 0,     null: false
     t.string   "unlock_token"
     t.string   "avatar_file_name"
     t.string   "avatar_content_type"
@@ -252,9 +252,17 @@ ActiveRecord::Schema.define(version: 20170105113735) do
     t.string   "thumbnail_content_type"
     t.integer  "thumbnail_file_size"
     t.datetime "thumbnail_updated_at"
-    t.boolean  "is_board_member",        default: false
+    t.boolean  "is_board_member",          default: false
     t.string   "phone"
     t.text     "description"
+    t.string   "s_avatar_file_name"
+    t.string   "s_avatar_content_type"
+    t.integer  "s_avatar_file_size"
+    t.datetime "s_avatar_updated_at"
+    t.string   "s_thumbnail_file_name"
+    t.string   "s_thumbnail_content_type"
+    t.integer  "s_thumbnail_file_size"
+    t.datetime "s_thumbnail_updated_at"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170105121009) do
+ActiveRecord::Schema.define(version: 20170105122805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -101,10 +101,14 @@ ActiveRecord::Schema.define(version: 20170105121009) do
     t.string   "background_image_content_type"
     t.integer  "background_image_file_size"
     t.datetime "background_image_updated_at"
-    t.boolean  "active",                        default: false, null: false
+    t.boolean  "active",                          default: false, null: false
     t.datetime "deactivated_at"
-    t.datetime "created_at",                                    null: false
-    t.datetime "updated_at",                                    null: false
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
+    t.string   "s_background_image_file_name"
+    t.string   "s_background_image_content_type"
+    t.integer  "s_background_image_file_size"
+    t.datetime "s_background_image_updated_at"
   end
 
   create_table "media_contents", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,6 +69,10 @@ ActiveRecord::Schema.define(version: 20170105113735) do
     t.string   "picture_content_type"
     t.integer  "picture_file_size"
     t.datetime "picture_updated_at"
+    t.string   "s_cover_picture_file_name"
+    t.string   "s_cover_picture_content_type"
+    t.integer  "s_cover_picture_file_size"
+    t.datetime "s_cover_picture_updated_at"
   end
 
   create_table "documents", force: :cascade do |t|


### PR DESCRIPTION
Adds new fields to hold pictures on Amazon for:

* users
* contents
* events
* partners

Requires `rails db:migrate`

After deploy we will copy the existing images to the new fields and then I'll create a new PR to get rid of these temp fields.

PLease give it a go to see if no pages are breaking! =)