### PR TITLE
Allows keeping albums on website in sync with flickr

### DIFF
--- a/backend/app/models/activity.rb
+++ b/backend/app/models/activity.rb
@@ -27,7 +27,7 @@ class Activity < Content
   scope :by_partners, ->(partners) { joins(:content_partners).where(content_partners: {id: partners})}
 
   def is_programme?
-    content_type.title == "Programme"
+    content_type && content_type.title == "Programme"
   end
 
   class << self

--- a/backend/app/views/backend/users/_form.html.slim
+++ b/backend/app/views/backend/users/_form.html.slim
@@ -1,5 +1,5 @@
 = render 'backend/shared/form/header', form: form, inputs: [{value: :last_name, title_placeholder: 'Lastname'}, {value: :first_name, title_placeholder: 'Firstname'}], fields: 2,
-  preview_url: main_app.staff_path(form.object)
+  preview_url: form.object.id && main_app.staff_path(form.object)
 
 div.fields
 


### PR DESCRIPTION
This PR adds a small step on updating albums from Flickr. It will track the ids of the pictures that an album has on Flickr and delete any existing pictures from the system, if they are not in that set of photos. This way albums on website can be kept in sync with Flickr.