### PR TITLE
Feature/media cards live content

### DIFF
--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -1,3 +1,9 @@
+<% content_for :social_cards %>
+  <%= render 'shared/social_cards', title: "GRID-Arendal: #{@activity.title}",
+    description: @activity.description.truncate(120),
+    img_src: @activity.media_content && @activity.media_content.medium_or_small_url
+<% end %>
+
 <div class="l-header-single">
   <div class="navigation -activities">
     <%= render 'shared/menu' %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,8 @@
+<% content_for :social_cards do %>
+  <%= render 'shared/social_cards', title: @section.title,
+    description: @section.social_description %>
+<% end %>
+
 <div class="l-header-home">
   <div class="overlay"></div>
   <div class="header-slider"></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,19 +5,14 @@
     <meta name='viewport' content='width=device-width, initial-scale=1.0'/>
     <meta name="turbolinks-cache-control" content="no-cache">
 
-    <!-- Twitter Card data -->
-     <meta name="twitter:site" content="@GRIDArendal"/>
-     <meta name="twitter:title" content="GRid Arendal"/>
-     <meta name="twitter:description" value=""/>
-     <meta name="twitter:card" value=""/>
-     <meta name="twitter:image:src" content=""/>
+    <meta name="description" content="GRID-Arendal is a Norwegian foundation working closely with the United Nations Environment. We are working on projects all around the world on biodiversity, environmental crime, climate change and Indigenous Peoples."/>
 
-     <!-- Open Graph data -->
-     <meta property="og:title" content="GRid Arendal"/>
-     <meta property="og:type" content="website"/>
-     <meta property="og:url" content=""/>
-     <meta property="og:image" content=""/>
-     <meta property="og:description" content=""/>
+    <% if @section %>
+      <%= render 'shared/social_cards', title: @section.title,
+        description: @section.social_description.presence %>
+    <% else %>
+      <%= yield :social_cards %>
+    <% end %>
 
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,10 @@
 
     <% if @section %>
       <%= render 'shared/social_cards', title: @section.title,
-        description: @section.social_description.presence %>
+        description: @section.social_description.presence,
+        img_src: @section.photo && @section.photo.photo_sizes.
+          where(label: PhotoSize::MEDIUM).try(:url)
+      %>
     <% else %>
       <%= yield :social_cards %>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,8 +10,7 @@
     <% if @section %>
       <%= render 'shared/social_cards', title: @section.title,
         description: @section.social_description.presence,
-        img_src: @section.photo && @section.photo.photo_sizes.
-          where(label: PhotoSize::MEDIUM).try(:url)
+        img_src: @section.photo && @section.photo.medium_or_small_url
       %>
     <% else %>
       <%= yield :social_cards %>

--- a/app/views/shared/_social_cards.html.erb
+++ b/app/views/shared/_social_cards.html.erb
@@ -1,5 +1,6 @@
 <% title ||= "GRID-Arendal Website" %>
 <% description ||= "GRID-Arendal is a Norwegian foundation working closely with the United Nations Environment. We are working on projects all around the world on biodiversity, environmental crime, climate change and Indigenous Peoples." %>
+<% img_src ||= "" %>
 
 <meta itemprop="name" content="<%= title %>">
 <meta itemprop="description" content="<%= description %>">
@@ -10,12 +11,12 @@
 <meta name="twitter:title" content="<%= title %>"/>
 <meta name="twitter:creator" content="@vizzuality"/>
 <meta name="twitter:description" value="<%= description %>"/>
-<meta name="twitter:card" value=""/>
-<meta name="twitter:image:src" content=""/>
+<meta name="twitter:card" value="<%= description %>"/>
+<meta name="twitter:image:src" content="<%= img_src %>"/>
 
 <!-- Open Graph data -->
 <meta property="og:title" content="<%= title %>"/>
 <meta property="og:type" content="website"/>
 <meta property="og:url" content="<%= request.original_url %>"/>
-<meta property="og:image" content=""/>
+<meta property="og:image" content="<%= img_src %>"/>
 <meta property="og:description" content="<%= description %>"/>

--- a/app/views/shared/_social_cards.html.erb
+++ b/app/views/shared/_social_cards.html.erb
@@ -1,0 +1,21 @@
+<% title ||= "GRID-Arendal Website" %>
+<% description ||= "GRID-Arendal is a Norwegian foundation working closely with the United Nations Environment. We are working on projects all around the world on biodiversity, environmental crime, climate change and Indigenous Peoples." %>
+
+<meta itemprop="name" content="<%= title %>">
+<meta itemprop="description" content="<%= description %>">
+<meta itemprop="image" content="">
+
+<!-- Twitter Card data -->
+<meta name="twitter:site" content="@GRIDArendal"/>
+<meta name="twitter:title" content="<%= title %>"/>
+<meta name="twitter:creator" content="@vizzuality"/>
+<meta name="twitter:description" value="<%= description %>"/>
+<meta name="twitter:card" value=""/>
+<meta name="twitter:image:src" content=""/>
+
+<!-- Open Graph data -->
+<meta property="og:title" content="<%= title %>"/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="<%= request.original_url %>"/>
+<meta property="og:image" content=""/>
+<meta property="og:description" content="<%= description %>"/>

--- a/backend/app/assets/javascripts/backend/router.js
+++ b/backend/app/assets/javascripts/backend/router.js
@@ -52,6 +52,9 @@
       'manage/tags': 'BackOfficeHome#index',
       'manage/tags/:id(/:action)': 'BackOfficeHome#show',
       'manage/tags/new': 'BackOfficeHome#show',
+      'manage/site_sections': 'BackOfficeHome#index',
+      'manage/site_sections/:id(/:action)': 'BackOfficeHome#show',
+      'manage/site_sections/new': 'BackOfficeHome#show',
     },
 
     initialize: function() {

--- a/backend/app/controllers/backend/site_sections_controller.rb
+++ b/backend/app/controllers/backend/site_sections_controller.rb
@@ -7,6 +7,7 @@ module Backend
 
     before_action :set_site_section,  except: [:index]
     before_action :set_site_sections
+    before_action :set_photos, only: [:edit]
 
     def index
     end
@@ -18,6 +19,7 @@ module Backend
       if @site_section.update(site_section_params)
         redirect_to [:edit, @site_section], notice: 'Section updated'
       else
+        set_photos
         render :edit
       end
     end
@@ -41,6 +43,13 @@ module Backend
 
       def site_section_params
         params.require(:site_section).permit!
+      end
+
+      def set_photos
+        @photos = Photo
+          .order_by_date_behind_value(@site_section.photo_id.present? ? @site_section.photo_id : 0)
+          .includes(:photo_sizes)
+          .limit(20)
       end
   end
 end

--- a/backend/app/models/photo.rb
+++ b/backend/app/models/photo.rb
@@ -25,4 +25,20 @@ class Photo < MediaContent
   delegate :activities, to: :album
   delegate :publications, to: :album
   delegate :news_article, to: :album
+
+  def medium_or_small_url
+    ordr = <<-SQL
+      CASE
+        WHEN label = '#{PhotoSize::MEDIUM}'
+          THEN 0
+        WHEN label = '#{PhotoSize::SMALL}'
+          THEN 1
+        ELSE 3
+      END
+    SQL
+    photo_sizes.
+      where(label: [PhotoSize::MEDIUM, PhotoSize::SMALL]).
+      where.not(url: nil).
+      order(ordr).limit(1).first.try(:url)
+  end
 end

--- a/backend/app/models/site_section.rb
+++ b/backend/app/models/site_section.rb
@@ -1,6 +1,7 @@
 class SiteSection < ApplicationRecord
+  belongs_to :photo
+
   SECTIONS = ["home", "activities", "publications", "news", "media_library",
               "about"]
-
   validates :section, uniqueness: true
 end

--- a/backend/app/views/backend/site_sections/_form.html.erb
+++ b/backend/app/views/backend/site_sections/_form.html.erb
@@ -1,8 +1,15 @@
 <%= render 'backend/shared/form/header', form: form,
-  inputs: [{value: :section, title_placeholder: 'Activity title'}],
+  inputs: [{value: :title, title_placeholder: 'Site Section title'}],
   preview_url: false %>
 
 <div class="fields">
+  <%= render 'backend/shared/form/field_select', form: form,
+    value: :section, collection: SiteSection::SECTIONS,
+    include_blank: false, label_txt: "Site Section", input_as: :select %>
+
   <%= render 'backend/shared/form/field_textarea', form: form,
     value: :description %>
+
+  <%= render 'backend/shared/form/field_textarea', form: form,
+    value: :social_description %>
 </div>

--- a/backend/app/views/backend/site_sections/_form.html.erb
+++ b/backend/app/views/backend/site_sections/_form.html.erb
@@ -10,6 +10,11 @@
   <%= render 'backend/shared/form/field_textarea', form: form,
     value: :description %>
 
+  <%= render 'backend/shared/form/field_photos', form: form, value: :photo_id,
+    label_txt: 'Social Media Picture',
+    photos: photos, selected_id: photo_id, with_search: true,
+    js_trigger_class: 'js-select-photo' %>
+
   <%= render 'backend/shared/form/field_textarea', form: form,
     value: :social_description %>
 </div>

--- a/backend/app/views/backend/site_sections/_site_sections.html.erb
+++ b/backend/app/views/backend/site_sections/_site_sections.html.erb
@@ -4,7 +4,7 @@
   <% @site_sections.each do |site_section| %>
     <%= render 'backend/shared/index_item',
       item: site_section,
-      title: site_section.section.titleize,
+      title: site_section.title,
       selected: action_name != "index" && @site_section == site_section
     %>
   <% end %>

--- a/backend/app/views/backend/site_sections/edit.html.erb
+++ b/backend/app/views/backend/site_sections/edit.html.erb
@@ -4,6 +4,7 @@
 
 <div class="l-items-detail">
   <%= simple_form_for @site_section, html: { class: 'c-form' } do |f| %>
-    <%= render 'form', form: f %>
+    <%= render 'form', form: f, photos: @photos,
+      photo_id: @site_section.photo_id %>
   <% end %>
 </div>

--- a/db/migrate/20170125132503_add_title_and_social_description_to_site_sections.rb
+++ b/db/migrate/20170125132503_add_title_and_social_description_to_site_sections.rb
@@ -1,0 +1,6 @@
+class AddTitleAndSocialDescriptionToSiteSections < ActiveRecord::Migration[5.0]
+  def change
+    add_column :site_sections, :title, :string
+    add_column :site_sections, :social_description, :text
+  end
+end

--- a/db/migrate/20170125142623_add_photo_id_to_site_sections.rb
+++ b/db/migrate/20170125142623_add_photo_id_to_site_sections.rb
@@ -1,0 +1,6 @@
+class AddPhotoIdToSiteSections < ActiveRecord::Migration[5.0]
+  def change
+    add_column :site_sections, :photo_id, :integer
+    add_foreign_key "site_sections", "media_contents", column: "photo_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170125132503) do
+ActiveRecord::Schema.define(version: 20170125142623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -224,6 +224,7 @@ ActiveRecord::Schema.define(version: 20170125132503) do
     t.datetime "updated_at",         null: false
     t.string   "title"
     t.text     "social_description"
+    t.integer  "photo_id"
   end
 
   create_table "taggings", force: :cascade do |t|
@@ -338,5 +339,6 @@ ActiveRecord::Schema.define(version: 20170125132503) do
   add_foreign_key "photo_sizes", "media_contents", column: "photo_id"
   add_foreign_key "related_contents", "contents", column: "activity_id"
   add_foreign_key "related_contents", "contents", column: "publication_id"
+  add_foreign_key "site_sections", "media_contents", column: "photo_id"
   add_foreign_key "weblinks", "contents", column: "publication_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170119104736) do
+ActiveRecord::Schema.define(version: 20170125132503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -220,8 +220,10 @@ ActiveRecord::Schema.define(version: 20170119104736) do
   create_table "site_sections", force: :cascade do |t|
     t.string   "section"
     t.text     "description"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.string   "title"
+    t.text     "social_description"
   end
 
   create_table "taggings", force: :cascade do |t|


### PR DESCRIPTION
* Adds fields to manage more content under site_sections
* Adds social_cards dynamic information
* Applies method to activities show page.

Requires: `rails db:migrate`

Once deployed we will need to update the title on the SiteSections, as this PR starts using "section" as a slug, and adds a proper title field.

Haven't done the social cards for publications and media_library as there's another PR with a bunch of changes on those pages, so didn't want to get any conflicts.