### PR TITLE
Show all graphics within a collection rather than just cover graphic

### DIFF
--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -115,7 +115,7 @@
 <% end %>
 
 <% if @publication.media_contents.any? %>
-  <%= render 'shared/related_media', media_contents: @publication.media_contents, link: media_path, sectionClass: 'content -color-2' %>
+  <%= render 'shared/related_media', media_contents: @publication.media_contents_with_graphics_expanded, link: media_path, sectionClass: 'content -color-2' %>
 <% end %>
 
 <%= render 'shared/footer' %>

--- a/backend/app/models/publication.rb
+++ b/backend/app/models/publication.rb
@@ -29,6 +29,14 @@ class Publication < Content
   scope :filter_or_older_pubs, ->(years) {where('EXTRACT(year from content_date) IN (?) OR EXTRACT(year from content_date) < ?', years, Date.today.year-5)}
   scope :by_years, ->(years) { where('EXTRACT(year from content_date) IN (?)', years) }
 
+  def media_contents_with_graphics_expanded
+    media_contents.joins(
+      "LEFT JOIN media_contents graphics
+      ON graphics.album_id = media_contents.id
+      AND graphics.type = '#{MediaContent::TYPE_GRAPHIC}'"
+    ).select('graphics.*')
+  end
+
   class << self
     def fetch_all(options)
       tags = options['tags'].split(',')               if options['tags'].present?

--- a/backend/app/models/publication.rb
+++ b/backend/app/models/publication.rb
@@ -30,11 +30,13 @@ class Publication < Content
   scope :by_years, ->(years) { where('EXTRACT(year from content_date) IN (?)', years) }
 
   def media_contents_with_graphics_expanded
-    media_contents.joins(
-      "LEFT JOIN media_contents graphics
-      ON graphics.album_id = media_contents.id
-      AND graphics.type = '#{MediaContent::TYPE_GRAPHIC}'"
-    ).select('graphics.*')
+    media_contents.map do |media|
+      if media.type == MediaContent::TYPE_COLLECTION
+        media.items
+      else
+        media
+      end
+    end.flatten
   end
 
   class << self


### PR DESCRIPTION
Adds a new getter to fetch all graphics objects for a publication, rather than just the collection objects.