### PR TITLE
feature/avatars-performance

### DIFF
--- a/app/assets/stylesheets/components/_c-staff.scss
+++ b/app/assets/stylesheets/components/_c-staff.scss
@@ -16,8 +16,7 @@ $staff-border-width: rem(3px);
       background-repeat: no-repeat;
       background-size: cover;
       background-position: center;
-      mix-blend-mode: multiply;
-      filter: saturate(10%);
+      mix-blend-mode: luminosity;
 
       &:before {
         content: "";


### PR DESCRIPTION
We go back with the blend-mode, so we have the good behaviour in Chrome & Firefox.
In IE & Safari the avatars are going to be show it without any transforms.