### PR TITLE
fix/header-without-photo

### DIFF
--- a/app/assets/stylesheets/layouts/_l-header-single.scss
+++ b/app/assets/stylesheets/layouts/_l-header-single.scss
@@ -149,9 +149,18 @@
         }
       }
 
+      &:not(.-picture) {
+        max-height: none !important;
+        height: auto !important;
+
+        .section-menu {
+          position: relative !important;
+        }
+      }
     }
 
-    &.-publications, &.-media-library {
+    &.-publications,
+    &.-media-library {
       @media screen and (min-width: $screen-m) {
         display: none;
       }


### PR DESCRIPTION
This PR fixes this behaviour:
![captura de pantalla 2017-02-14 a las 8 23 16 2](https://cloud.githubusercontent.com/assets/1432880/22919396/fb96ebc6-f28f-11e6-91be-c32a778bb9de.png)

I don't really like it use the `!important`, but in this case, I think that's the cleanest way because this classes have a lot of variations from the media queries.