### PR TITLE
fix/related-media-overflow-title

### DIFF
--- a/app/assets/stylesheets/components/_c-related-media.scss
+++ b/app/assets/stylesheets/components/_c-related-media.scss
@@ -19,10 +19,12 @@
 
   .name {
     left: 0;
-    bottom: rem(-35px);
+    top: rem(607px);
+    width: 70%;
+    white-space: normal;
 
     @media screen and (min-width: $screen-m) {
-      bottom: rem(-36px);
+      top: rem(608px);
     }
   }
 


### PR DESCRIPTION
Fix the title of the related media items when the text is too long