### PR TITLE
fix/meta-og-description

### DIFF
--- a/app/views/shared/_social_cards.html.erb
+++ b/app/views/shared/_social_cards.html.erb
@@ -1,5 +1,5 @@
 <% title ||= "GRID-Arendal Website" %>
-<% description ||= "GRID-Arendal is a Norwegian foundation working closely with the United Nations Environment. We are working on projects all around the world on biodiversity, environmental crime, climate change and Indigenous Peoples." %>
+<% description = description.present? ? strip_tags(description) : "GRID-Arendal is a Norwegian foundation working closely with the United Nations Environment. We are working on projects all around the world on biodiversity, environmental crime, climate change and Indigenous Peoples." %>
 <% img_src ||= image_url("header#{[1,2,3,4,5,6,7].shuffle.first}.jpg") %>
 
 <meta itemprop="name" content="<%= title %>">


### PR DESCRIPTION
Remove all HTML tags from the meta og description.
This change fixes the `<p>` mistake when a url has been shared
![thumbnail](https://cloud.githubusercontent.com/assets/1432880/24138941/6e72be90-0e1a-11e7-8543-9a050626cb41.png)
