### PR TITLE
feature/update-time-ago-in-words

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,11 +23,14 @@ en:
   datetime:
     distance_in_words:
       about_x_minutes:
-        one:   "1 minute ago"
-        other: "%{count} minutes ago"
+        one:   "today"
+        other: "today"
       x_minutes:
-        one:   "1 minute ago"
-        other: "%{count} minutes ago"
+        one:   "today"
+        other: "today"
+      about_x_hours:
+        one:   "today"
+        other: "today"
       about_x_days:
         one:   "1 day ago"
         other: "%{count} days ago"


### PR DESCRIPTION
The time_ago_in_words function always return "today" when the date as less as 1 day