### PR TITLE
Added "page not found (404)" page title

### DIFF
--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,3 +1,4 @@
+<% title("Page not found (404)") %>
 <style>
   body, html {
     height: 100%;


### PR DESCRIPTION
404 pages should have "page not found" in their page title. Not just GridArendal.